### PR TITLE
feat: Introduce workout plan v2.2 with exercise templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist
 test-results/
 playwright-report/
 public/workout-plan-v2.1.json
+public/workout-plan-v2.2.json

--- a/migrate-to-v2.2.mjs
+++ b/migrate-to-v2.2.mjs
@@ -1,0 +1,521 @@
+#!/usr/bin/env node
+/**
+ * Migration script to convert workout-plan-v2.1.json to workout-plan-v2.2.json
+ * 
+ * This script:
+ * 1. Identifies common exercises that appear multiple times with the same base properties
+ * 2. Creates exercise templates for these common exercises
+ * 3. Replaces full exercise definitions with $ref references
+ * 4. Allows overriding specific fields that differ between instances
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Read the v2.1 workout plan
+const inputPath = path.join(__dirname, 'workout-plan-v2.1.json');
+const outputPath = path.join(__dirname, 'workout-plan-v2.2.json');
+
+const plan = JSON.parse(fs.readFileSync(inputPath, 'utf-8'));
+
+// Exercise templates to create based on frequency analysis
+// These are exercises that appear many times with mostly the same properties
+const exerciseTemplateDefinitions = [
+  // Warmup exercises (appear 40+ times each)
+  {
+    id: 'warmup-rower-zone1',
+    exerciseName: 'Rower (Zone 1)',
+    category: 'warmup',
+    sets: 1,
+    notes: 'Warm-up. Min 1-2: Easy pace to warm up (Zone 1).',
+    repsType: 'time',
+    repsValue: 120,
+    repsUnit: 'seconds',
+    loadMin: 0,
+    loadMax: 0,
+    loadUnit: 'bodyweight',
+    restSeconds: 30
+  },
+  {
+    id: 'warmup-rower-zone2',
+    exerciseName: 'Rower (Zone 2)',
+    category: 'warmup',
+    sets: 1,
+    notes: 'Warm-up. Min 3-4: Moderate intensity (Zone 2).',
+    repsType: 'time',
+    repsValue: 120,
+    repsUnit: 'seconds',
+    loadMin: 0,
+    loadMax: 0,
+    loadUnit: 'bodyweight',
+    restSeconds: 30
+  },
+  {
+    id: 'warmup-rower-sprints',
+    exerciseName: 'Rower Sprints',
+    category: 'warmup',
+    sets: 3,
+    notes: 'Warm-up. Min 5: 3 x 10s Sprints to wake up CNS.',
+    repsType: 'time',
+    repsValue: 10,
+    repsUnit: 'seconds',
+    loadMin: 0,
+    loadMax: 0,
+    loadUnit: 'bodyweight',
+    restSeconds: 30
+  },
+  {
+    id: 'warmup-band-pull-aparts',
+    exerciseName: 'Band Pull-Aparts',
+    category: 'warmup',
+    sets: 1,
+    notes: 'Warm-up. Global Tendon Prep.',
+    loadMin: 1,
+    loadMax: 1,
+    loadUnit: 'band',
+    repsType: 'reps',
+    repsValue: 20,
+    restSeconds: 30
+  },
+  {
+    id: 'warmup-band-external-rotations',
+    exerciseName: 'Band External Rotations',
+    category: 'warmup',
+    sets: 1,
+    notes: 'Warm-up. Global Tendon Prep. Pin elbow to ribcage using a towel roll.',
+    loadMin: 1,
+    loadMax: 1,
+    loadUnit: 'band',
+    repsType: 'reps',
+    repsValue: 15,
+    repsPerSide: true,
+    restSeconds: 30,
+    cues: ['Elbow pinned', 'Rotate away from belly']
+  },
+  {
+    id: 'warmup-scapular-pullups',
+    exerciseName: 'Scapular Pull-Ups (3s ISO-HOLD)',
+    category: 'warmup',
+    sets: 3,
+    notes: 'Warm-up. Global Tendon Prep. 3s ISO-HOLD at top. No bouncy reps.',
+    repsType: 'reps',
+    repsValue: 5,
+    loadMin: 0,
+    loadMax: 0,
+    loadUnit: 'bodyweight',
+    restSeconds: 30,
+    alternatives: ['Lat Pulldowns', 'Ring Rows', 'Assisted Pull-Ups'],
+    cues: ['Straight arms', 'Depress scapula', 'Hold 3s']
+  },
+  {
+    id: 'warmup-passive-bar-hang',
+    exerciseName: 'Passive Bar Hang',
+    category: 'warmup',
+    sets: 1,
+    notes: 'Warm-up. Global Tendon Prep. Passive hang.',
+    repsType: 'time',
+    repsValue: 30,
+    repsUnit: 'seconds',
+    loadMin: 0,
+    loadMax: 0,
+    loadUnit: 'bodyweight',
+    restSeconds: 30,
+    cues: ['Relax shoulders', 'Decompress spine']
+  },
+  
+  // Cooldown exercises (appear 18-19 times each)
+  {
+    id: 'cooldown-passive-dead-hang',
+    exerciseName: 'Passive Dead Hang',
+    category: 'cooldown',
+    sets: 1,
+    notes: 'Cool-down. Spinal decompression.',
+    repsType: 'time',
+    repsValue: 60,
+    repsUnit: 'seconds',
+    loadMin: 0,
+    loadMax: 0,
+    loadUnit: 'bodyweight',
+    restSeconds: 0
+  },
+  {
+    id: 'cooldown-butchers-block',
+    exerciseName: "Butcher's Block Stretch",
+    category: 'cooldown',
+    sets: 1,
+    notes: 'Cool-down. Targeting Lats/Triceps.',
+    repsType: 'time',
+    repsValue: 60,
+    repsUnit: 'seconds',
+    loadMin: 0,
+    loadMax: 0,
+    loadUnit: 'bodyweight',
+    restSeconds: 0
+  },
+  {
+    id: 'cooldown-cobra-stretch',
+    exerciseName: 'Cobra Stretch',
+    category: 'cooldown',
+    sets: 1,
+    notes: 'Cool-down. Releasing abs.',
+    repsType: 'time',
+    repsValue: 60,
+    repsUnit: 'seconds',
+    loadMin: 0,
+    loadMax: 0,
+    loadUnit: 'bodyweight',
+    restSeconds: 0
+  },
+  {
+    id: 'cooldown-wrist-extensor',
+    exerciseName: 'Wrist Extensor Stretch',
+    category: 'cooldown',
+    sets: 1,
+    notes: 'Cool-down. Forearm health.',
+    repsType: 'time',
+    repsValue: 30,
+    repsUnit: 'seconds',
+    repsPerSide: true,
+    loadMin: 0,
+    loadMax: 0,
+    loadUnit: 'bodyweight',
+    restSeconds: 0
+  },
+  {
+    id: 'cooldown-banded-pec-stretch',
+    exerciseName: 'Banded Pec Stretch',
+    category: 'cooldown',
+    sets: 1,
+    notes: 'Cool-down. Release tension from dips.',
+    repsType: 'time',
+    repsValue: 60,
+    repsUnit: 'seconds',
+    repsPerSide: true,
+    loadMin: 0,
+    loadMax: 0,
+    loadUnit: 'bodyweight',
+    restSeconds: 0
+  },
+  {
+    id: 'cooldown-lat-prayer',
+    exerciseName: 'Lat Prayer',
+    category: 'cooldown',
+    sets: 1,
+    notes: 'Cool-down. Lat release.',
+    repsType: 'time',
+    repsValue: 60,
+    repsUnit: 'seconds',
+    loadMin: 0,
+    loadMax: 0,
+    loadUnit: 'bodyweight',
+    restSeconds: 0
+  },
+  {
+    id: 'cooldown-standing-quad-stretch',
+    exerciseName: 'Standing Quad Stretch',
+    category: 'cooldown',
+    sets: 1,
+    notes: 'Cool-down. Quad release.',
+    repsType: 'time',
+    repsValue: 60,
+    repsUnit: 'seconds',
+    repsPerSide: true,
+    loadMin: 0,
+    loadMax: 0,
+    loadUnit: 'bodyweight',
+    restSeconds: 0
+  },
+  {
+    id: 'cooldown-couch-stretch',
+    exerciseName: 'Couch Stretch',
+    category: 'cooldown',
+    sets: 1,
+    notes: 'Cool-down. Hip flexor release.',
+    repsType: 'time',
+    repsValue: 90,
+    repsUnit: 'seconds',
+    repsPerSide: true,
+    loadMin: 0,
+    loadMax: 0,
+    loadUnit: 'bodyweight',
+    restSeconds: 0
+  },
+  {
+    id: 'cooldown-jefferson-curl',
+    exerciseName: 'Light Weighted Jefferson Curl',
+    category: 'cooldown',
+    sets: 1,
+    notes: 'Cool-down. Spinal segmentation. Tuck chin, roll down one vertebra at a time.',
+    loadMin: 5,
+    loadMax: 10,
+    loadUnit: 'kg',
+    repsType: 'time',
+    repsValue: 120,
+    repsUnit: 'seconds',
+    restSeconds: 0,
+    cues: ['Use empty bar or light DB', 'Do not use PVC', 'Passive pull']
+  },
+  {
+    id: 'cooldown-90-90-hip-rotations',
+    exerciseName: '90/90 Hip Rotations',
+    category: 'cooldown',
+    sets: 1,
+    notes: 'Cool-down. Hip mobility.',
+    repsType: 'reps',
+    repsValue: 10,
+    repsPerSide: true,
+    loadMin: 0,
+    loadMax: 0,
+    loadUnit: 'bodyweight',
+    restSeconds: 0
+  },
+  
+  // Main/Accessory exercises (appear 10+ times)
+  {
+    id: 'main-goblet-squats',
+    exerciseName: 'Goblet Squats',
+    category: 'main',
+    sets: 3,
+    notes: 'Pattern Maint. Reinforce healthy squat patterns. Ankle mobility focus.',
+    loadMin: 16,
+    loadMax: 24,
+    loadUnit: 'kg',
+    repsType: 'reps',
+    repsValue: 10,
+    restSeconds: 120,
+    cues: ['Upright torso', 'Knees track toes']
+  },
+  {
+    id: 'accessory-face-pulls',
+    exerciseName: 'Face Pulls',
+    category: 'accessory',
+    sets: 3,
+    notes: 'Accessory. Tempo 2-1-1-0. Upper back health.',
+    loadMin: 2,
+    loadMax: 2,
+    loadUnit: 'band',
+    repsType: 'reps',
+    repsValue: 15,
+    restSeconds: 60
+  },
+  
+  // Core exercises
+  {
+    id: 'core-hollow-rocks',
+    exerciseName: 'Hollow Rocks',
+    category: 'core',
+    sets: 3,
+    notes: 'Core Work. Tempo controlled. Lower back must stay glued.',
+    loadMin: 0,
+    loadMax: 0,
+    loadUnit: 'bodyweight',
+    repsType: 'reps',
+    repsMin: 12,
+    repsMax: 15,
+    restSeconds: 60,
+    alternatives: ['V-Ups', 'Dead Bugs']
+  },
+  {
+    id: 'core-weighted-hollow-rocks',
+    exerciseName: 'Weighted Hollow Rocks',
+    category: 'core',
+    sets: 3,
+    notes: 'Core Work. Arms straight overhead. If lower back arches, drop weight immediately.',
+    loadMin: 1.25,
+    loadMax: 2.5,
+    loadUnit: 'kg',
+    repsType: 'reps',
+    repsMin: 12,
+    repsMax: 15,
+    restSeconds: 60,
+    progressionNotes: 'Start 1.25/2.5kg. Move to 5kg only when holding shape perfectly for 45s.'
+  }
+];
+
+// Build a map for quick template lookup by exercise name
+const templateByName = new Map();
+for (const template of exerciseTemplateDefinitions) {
+  templateByName.set(template.exerciseName, template);
+}
+
+/**
+ * Compare exercise with template to find which fields differ
+ */
+function getOverrides(exercise, template) {
+  const overrides = {};
+  const fieldsToCompare = [
+    'exerciseName', 'category', 'sets', 'restSeconds', 'rpe', 'notes',
+    'loadMin', 'loadMax', 'loadUnit', 'loadPerHand',
+    'repsType', 'repsValue', 'repsMin', 'repsMax', 'repsUnit', 'repsPerSide', 'repsModifier',
+    'tempoEccentric', 'tempoPauseBottom', 'tempoConcentric', 'tempoPauseTop',
+    'isEmom', 'isUnilateral', 'supersetGroup', 'progressionNotes'
+  ];
+  
+  for (const field of fieldsToCompare) {
+    const exerciseValue = exercise[field];
+    const templateValue = template[field];
+    
+    // Skip if both undefined/null
+    if (exerciseValue == null && templateValue == null) continue;
+    
+    // Compare values - JSON stringify for arrays/objects
+    const exStr = JSON.stringify(exerciseValue);
+    const tmplStr = JSON.stringify(templateValue);
+    
+    if (exStr !== tmplStr) {
+      overrides[field] = exerciseValue;
+    }
+  }
+  
+  // Handle arrays separately (alternatives, cues)
+  if (exercise.alternatives) {
+    const exAlt = JSON.stringify(exercise.alternatives || []);
+    const tmplAlt = JSON.stringify(template.alternatives || []);
+    if (exAlt !== tmplAlt) {
+      overrides.alternatives = exercise.alternatives;
+    }
+  }
+  if (exercise.cues) {
+    const exCues = JSON.stringify(exercise.cues || []);
+    const tmplCues = JSON.stringify(template.cues || []);
+    if (exCues !== tmplCues) {
+      overrides.cues = exercise.cues;
+    }
+  }
+  
+  return overrides;
+}
+
+/**
+ * Convert an exercise to use template reference if applicable
+ */
+function convertExercise(exercise) {
+  const template = templateByName.get(exercise.exerciseName);
+  
+  if (!template) {
+    // No template for this exercise, keep as-is
+    return exercise;
+  }
+  
+  const overrides = getOverrides(exercise, template);
+  
+  // If too many overrides, keep as full exercise
+  // (more than 5 overrides means the template doesn't save much)
+  if (Object.keys(overrides).length > 5) {
+    return exercise;
+  }
+  
+  // Create reference with overrides
+  const ref = { $ref: template.id };
+  
+  // Add overrides
+  for (const [key, value] of Object.entries(overrides)) {
+    ref[key] = value;
+  }
+  
+  return ref;
+}
+
+/**
+ * Process exercises array, converting to references where applicable
+ */
+function processExercises(exercises) {
+  if (!exercises) return exercises;
+  return exercises.map(convertExercise);
+}
+
+/**
+ * Process a day template
+ */
+function processDayTemplate(dayTemplate) {
+  return {
+    ...dayTemplate,
+    exercises: processExercises(dayTemplate.exercises)
+  };
+}
+
+/**
+ * Process a day
+ */
+function processDay(day) {
+  if (day.$ref) {
+    // Day uses a reference, keep as-is
+    return day;
+  }
+  
+  return {
+    ...day,
+    exercises: processExercises(day.exercises)
+  };
+}
+
+// Create the v2.2 plan
+const v22Plan = {
+  $schema: './workout-plan-v2.2.schema.json',
+  formatVersion: '2.2.0',
+  plan: {
+    ...plan.plan,
+    // Add exercise templates
+    exerciseTemplates: exerciseTemplateDefinitions,
+    // Process day templates
+    dayTemplates: plan.plan.dayTemplates?.map(processDayTemplate),
+    // Process phases
+    phases: plan.plan.phases.map(phase => ({
+      ...phase,
+      weeks: phase.weeks.map(week => ({
+        ...week,
+        days: week.days.map(processDay)
+      }))
+    }))
+  }
+};
+
+// Update lastModified
+v22Plan.plan.lastModified = new Date().toISOString();
+
+// Write output
+fs.writeFileSync(outputPath, JSON.stringify(v22Plan, null, 2));
+
+// Calculate statistics
+let totalExercises = 0;
+let templatedExercises = 0;
+
+function countExercises(exercises) {
+  if (!exercises) return;
+  for (const ex of exercises) {
+    totalExercises++;
+    if (ex.$ref) templatedExercises++;
+  }
+}
+
+for (const phase of v22Plan.plan.phases) {
+  for (const week of phase.weeks) {
+    for (const day of week.days) {
+      if (day.exercises) {
+        countExercises(day.exercises);
+      }
+    }
+  }
+}
+
+if (v22Plan.plan.dayTemplates) {
+  for (const template of v22Plan.plan.dayTemplates) {
+    countExercises(template.exercises);
+  }
+}
+
+console.log('Migration complete!');
+console.log(`Output: ${outputPath}`);
+console.log(`Exercise templates created: ${exerciseTemplateDefinitions.length}`);
+console.log(`Total exercises processed: ${totalExercises}`);
+console.log(`Exercises using templates: ${templatedExercises}`);
+console.log(`Reduction: ${((templatedExercises / totalExercises) * 100).toFixed(1)}%`);
+
+// Also show file size reduction
+const originalSize = fs.statSync(inputPath).size;
+const newSize = fs.statSync(outputPath).size;
+console.log(`File size: ${(originalSize / 1024).toFixed(1)}KB -> ${(newSize / 1024).toFixed(1)}KB (${((1 - newSize / originalSize) * 100).toFixed(1)}% reduction)`);

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "prebuild": "cp workout-plan-v2.1.json public/",
-    "predev": "cp workout-plan-v2.1.json public/",
+    "prebuild": "cp workout-plan-v2.2.json public/",
+    "predev": "cp workout-plan-v2.2.json public/",
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -54,7 +54,7 @@ root.render(<LoadingScreen />);
 
 // Load both schedule and exercise library data with timeout
 Promise.all([
-    fetchWithTimeout(`${import.meta.env.BASE_URL}workout-plan-v2.1.json`, FETCH_TIMEOUT_MS).then(response => {
+    fetchWithTimeout(`${import.meta.env.BASE_URL}workout-plan-v2.2.json`, FETCH_TIMEOUT_MS).then(response => {
         if (!response.ok) {
             throw new Error(`HTTP error loading schedule! status: ${response.status}`);
         }

--- a/src/test/workoutPlanUtils.test.jsx
+++ b/src/test/workoutPlanUtils.test.jsx
@@ -186,7 +186,7 @@ describe('Workout Plan Utilities', () => {
     });
 
     it('should throw error for invalid v2 format', () => {
-      expect(() => convertV2ToInternal({})).toThrow('Invalid v2.0.0/v2.1.0 workout plan format');
+      expect(() => convertV2ToInternal({})).toThrow('Invalid v2.0.0/v2.1.0/v2.2.0 workout plan format');
       expect(() => convertV2ToInternal({ formatVersion: '2.0.0' })).toThrow();
     });
 
@@ -405,6 +405,194 @@ describe('Workout Plan Utilities', () => {
       };
 
       expect(() => convertV2ToInternal(v21DataWithBadRef)).toThrow('Day template "non-existent-template" not found');
+    });
+
+    it('should resolve exercise references from exerciseTemplates in v2.2.0', () => {
+      // v2.2.0 data with exercise templates and references
+      const v22Data = {
+        formatVersion: '2.2.0',
+        plan: {
+          id: 'test-v22-plan',
+          name: 'Test v2.2 Plan',
+          description: 'Testing v2.2 format with exercise templates',
+          author: null,
+          durationWeeks: 1,
+          goals: [],
+          targetLevel: 'intermediate',
+          equipment: ['pull-up-bar'],
+          exerciseTemplates: [
+            {
+              id: 'warmup-rower-zone1',
+              exerciseName: 'Rower (Zone 1)',
+              category: 'warmup',
+              sets: 1,
+              notes: 'Warm-up. Easy pace.',
+              repsType: 'time',
+              repsValue: 120,
+              repsUnit: 'seconds',
+              loadMin: 0,
+              loadMax: 0,
+              loadUnit: 'bodyweight',
+              restSeconds: 30
+            },
+            {
+              id: 'cooldown-stretch',
+              exerciseName: 'Lat Stretch',
+              category: 'cooldown',
+              sets: 1,
+              notes: 'Cool-down. Hold stretch.',
+              repsType: 'time',
+              repsValue: 60,
+              repsUnit: 'seconds',
+              loadMin: 0,
+              loadMax: 0,
+              loadUnit: 'bodyweight',
+              restSeconds: 0
+            }
+          ],
+          dayTemplates: [],
+          phases: [
+            {
+              phaseNumber: 1,
+              name: 'Test Phase',
+              description: 'Testing v2.2 features',
+              startWeek: 1,
+              endWeek: 1,
+              focus: 'volume',
+              weeks: [
+                {
+                  weekNumber: 1,
+                  description: null,
+                  focus: null,
+                  volumeLevel: 'moderate',
+                  intensityLevel: 'low',
+                  days: [
+                    {
+                      dayNumber: 1,
+                      name: 'Test Day',
+                      type: 'strength',
+                      estimatedDuration: 30,
+                      description: null,
+                      exercises: [
+                        // Reference to warmup template
+                        { $ref: 'warmup-rower-zone1' },
+                        // Full exercise definition (inline)
+                        {
+                          exerciseName: 'Pull-Ups',
+                          category: 'main',
+                          sets: 3,
+                          repsType: 'reps',
+                          repsValue: 8,
+                          loadMin: 0,
+                          loadMax: 0,
+                          loadUnit: 'bodyweight',
+                          restSeconds: 120,
+                          notes: 'Main exercise'
+                        },
+                        // Reference with override
+                        { 
+                          $ref: 'cooldown-stretch',
+                          notes: 'Custom note for this day',
+                          repsValue: 90
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      };
+
+      const result = convertV2ToInternal(v22Data);
+
+      // Should have 3 exercises
+      expect(result.length).toBe(3);
+
+      // Check resolved warmup template
+      expect(result[0]).toMatchObject({
+        w: 1,
+        d: 1,
+        ex: 'Rower (Zone 1)',
+        s: 1,
+        n: 'Warm-up. Easy pace.',
+        category: 'warmup',
+        restSeconds: 30
+      });
+      expect(result[0].repsRange.type).toBe('time');
+      expect(result[0].repsRange.value).toBe(120);
+
+      // Check inline exercise
+      expect(result[1]).toMatchObject({
+        w: 1,
+        d: 1,
+        ex: 'Pull-Ups',
+        s: 3,
+        n: 'Main exercise',
+        category: 'main',
+        restSeconds: 120
+      });
+
+      // Check resolved template with overrides
+      expect(result[2]).toMatchObject({
+        w: 1,
+        d: 1,
+        ex: 'Lat Stretch',
+        s: 1,
+        n: 'Custom note for this day', // overridden
+        category: 'cooldown',
+        restSeconds: 0
+      });
+      expect(result[2].repsRange.value).toBe(90); // overridden from 60
+    });
+
+    it('should throw error for missing exercise template reference in v2.2.0', () => {
+      const v22DataWithBadRef = {
+        formatVersion: '2.2.0',
+        plan: {
+          id: 'bad-exercise-ref-plan',
+          name: 'Bad Exercise Ref Plan',
+          description: null,
+          author: null,
+          durationWeeks: 1,
+          goals: [],
+          targetLevel: 'beginner',
+          equipment: [],
+          exerciseTemplates: [],
+          dayTemplates: [],
+          phases: [
+            {
+              phaseNumber: 1,
+              name: 'Test',
+              description: null,
+              startWeek: 1,
+              endWeek: 1,
+              focus: 'volume',
+              weeks: [
+                {
+                  weekNumber: 1,
+                  description: null,
+                  focus: null,
+                  volumeLevel: 'low',
+                  intensityLevel: 'low',
+                  days: [
+                    {
+                      dayNumber: 1,
+                      name: 'Test Day',
+                      exercises: [
+                        { $ref: 'non-existent-exercise' }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      };
+
+      expect(() => convertV2ToInternal(v22DataWithBadRef)).toThrow('Exercise template "non-existent-exercise" not found');
     });
   });
 

--- a/src/workout-plan-utils.ts
+++ b/src/workout-plan-utils.ts
@@ -98,7 +98,7 @@ export function parseLoadRange(load: string | null | undefined): LoadRange | nul
 /**
  * Format version string
  */
-export type FormatVersion = '2.0.0' | '2.1.0';
+export type FormatVersion = '2.0.0' | '2.1.0' | '2.2.0';
 
 /**
  * Structured reps data for internal use
@@ -187,6 +187,81 @@ export type LoadUnit = 'kg' | 'band' | 'bodyweight' | 'percent';
 export type RepsType = 'reps' | 'time' | 'ladder' | 'amrap' | 'rm' | 'max' | 'effort' | 'submax' | 'none';
 
 /**
+ * V2.2.0 exercise template definition
+ * Exercise templates allow defining common exercises once with all their default properties.
+ * When referenced via $ref, any field can be overridden.
+ */
+export interface V2ExerciseTemplate {
+  /** Unique identifier for this exercise template */
+  id: string;
+  /** Full exercise name as displayed to user */
+  exerciseName: string;
+  /** Number of sets */
+  sets?: number;
+  notes?: string;
+  category?: string;
+  restSeconds?: number;
+  rpe?: number;
+  alternatives?: string[];
+  progressionNotes?: string;
+  cues?: string[];
+  loadMin?: number;
+  loadMax?: number;
+  loadUnit?: LoadUnit;
+  loadPerHand?: boolean;
+  repsType?: RepsType;
+  repsValue?: number | number[] | null;
+  repsMin?: number;
+  repsMax?: number;
+  repsUnit?: 'seconds';
+  repsPerSide?: boolean;
+  repsModifier?: number;
+  tempoEccentric?: number;
+  tempoPauseBottom?: number;
+  tempoConcentric?: number;
+  tempoPauseTop?: number;
+  isEmom?: boolean;
+  isUnilateral?: boolean;
+  supersetGroup?: number;
+}
+
+/**
+ * V2.2.0 exercise reference - references an exercise template with optional overrides
+ */
+export interface V2ExerciseRef {
+  /** Reference to an exercise template ID */
+  $ref: string;
+  /** Override fields from the template */
+  exerciseName?: string;
+  sets?: number;
+  notes?: string;
+  category?: string;
+  restSeconds?: number;
+  rpe?: number;
+  alternatives?: string[];
+  progressionNotes?: string;
+  cues?: string[];
+  loadMin?: number;
+  loadMax?: number;
+  loadUnit?: LoadUnit;
+  loadPerHand?: boolean;
+  repsType?: RepsType;
+  repsValue?: number | number[] | null;
+  repsMin?: number;
+  repsMax?: number;
+  repsUnit?: 'seconds';
+  repsPerSide?: boolean;
+  repsModifier?: number;
+  tempoEccentric?: number;
+  tempoPauseBottom?: number;
+  tempoConcentric?: number;
+  tempoPauseTop?: number;
+  isEmom?: boolean;
+  isUnilateral?: boolean;
+  supersetGroup?: number;
+}
+
+/**
  * V2.0.0 exercise definition
  */
 export interface V2Exercise {
@@ -201,6 +276,10 @@ export interface V2Exercise {
   restSeconds?: number;
   /** Array of alternative exercise names or IDs */
   alternatives?: string[];
+  /** Progression notes for this exercise */
+  progressionNotes?: string;
+  /** Coaching cues */
+  cues?: string[];
 
   // ---- Legacy fields (deprecated, for backward compatibility) ----
   /** @deprecated Use repsType/repsValue/repsMin/repsMax instead */
@@ -269,7 +348,8 @@ export interface V2Day {
   description?: string | null;
   /** Reference to another day or template (v2.1+) */
   $ref?: string;
-  exercises?: V2Exercise[];
+  /** Exercises can be full definitions or references (v2.2+) */
+  exercises?: (V2Exercise | V2ExerciseRef)[];
 }
 
 /**
@@ -278,11 +358,14 @@ export interface V2Day {
 export interface V2DayTemplate {
   /** Unique ID for this template */
   id: string;
+  /** Default day number for this template */
+  dayNumber?: number;
   name?: string;
   type?: string;
   estimatedDuration?: number;
   description?: string | null;
-  exercises: V2Exercise[];
+  /** Exercises can be full definitions or references (v2.2+) */
+  exercises: (V2Exercise | V2ExerciseRef)[];
 }
 
 /**
@@ -318,16 +401,18 @@ export interface V2Plan {
   goals?: string[];
   targetLevel?: string;
   equipment?: string[];
+  /** Exercise templates for v2.2+ format */
+  exerciseTemplates?: V2ExerciseTemplate[];
   /** Day templates for v2.1+ format */
   dayTemplates?: V2DayTemplate[];
   phases: V2Phase[];
 }
 
 /**
- * V2.0.0/V2.1.0 format root structure
+ * V2.0.0/V2.1.0/V2.2.0 format root structure
  */
 export interface V2WorkoutPlan {
-  formatVersion: '2.0.0' | '2.1.0';
+  formatVersion: '2.0.0' | '2.1.0' | '2.2.0';
   plan: V2Plan;
 }
 
@@ -395,14 +480,15 @@ export interface PlanSummary {
 // ============================================================================
 
 /**
- * Validate v2.0.0 or v2.1.0 format
+ * Validate v2.0.0, v2.1.0, or v2.2.0 format
  */
 function validateV2Format(data: unknown): data is V2WorkoutPlan {
   if (!data || typeof data !== 'object') return false;
 
   const obj = data as Record<string, unknown>;
-  // Support both 2.0.0 and 2.1.0
-  if (!obj.formatVersion || (obj.formatVersion !== '2.0.0' && obj.formatVersion !== '2.1.0') || !obj.plan) return false;
+  // Support 2.0.0, 2.1.0, and 2.2.0
+  const validVersions = ['2.0.0', '2.1.0', '2.2.0'];
+  if (!obj.formatVersion || !validVersions.includes(obj.formatVersion as string) || !obj.plan) return false;
 
   const plan = obj.plan as Record<string, unknown>;
   return (
@@ -418,20 +504,100 @@ function validateV2Format(data: unknown): data is V2WorkoutPlan {
 // ============================================================================
 
 /**
+ * Check if an exercise entry is a reference (v2.2+)
+ */
+function isExerciseRef(exercise: V2Exercise | V2ExerciseRef): exercise is V2ExerciseRef {
+  return '$ref' in exercise && typeof exercise.$ref === 'string';
+}
+
+/**
+ * Resolve an exercise reference to a full exercise definition (v2.2+)
+ * @param exerciseOrRef - The exercise or exercise reference
+ * @param exerciseTemplates - Map of exercise templates by ID
+ * @returns The resolved exercise with all fields filled in
+ */
+function resolveExerciseReference(
+  exerciseOrRef: V2Exercise | V2ExerciseRef,
+  exerciseTemplates: Map<string, V2ExerciseTemplate>
+): V2Exercise {
+  // If it's already a full exercise, return it
+  if (!isExerciseRef(exerciseOrRef)) {
+    return exerciseOrRef;
+  }
+
+  // Find the template
+  const template = exerciseTemplates.get(exerciseOrRef.$ref);
+  if (!template) {
+    throw new Error(`Exercise template "${exerciseOrRef.$ref}" not found`);
+  }
+
+  // Merge template with overrides
+  // The reference can override any field from the template
+  const resolved: V2Exercise = {
+    exerciseName: exerciseOrRef.exerciseName ?? template.exerciseName,
+    sets: exerciseOrRef.sets ?? template.sets ?? 1,
+    notes: exerciseOrRef.notes ?? template.notes,
+    category: exerciseOrRef.category ?? template.category,
+    restSeconds: exerciseOrRef.restSeconds ?? template.restSeconds,
+    rpe: exerciseOrRef.rpe ?? template.rpe,
+    alternatives: exerciseOrRef.alternatives ?? template.alternatives,
+    progressionNotes: exerciseOrRef.progressionNotes ?? template.progressionNotes,
+    loadMin: exerciseOrRef.loadMin ?? template.loadMin,
+    loadMax: exerciseOrRef.loadMax ?? template.loadMax,
+    loadUnit: exerciseOrRef.loadUnit ?? template.loadUnit,
+    loadPerHand: exerciseOrRef.loadPerHand ?? template.loadPerHand,
+    repsType: exerciseOrRef.repsType ?? template.repsType,
+    repsValue: exerciseOrRef.repsValue ?? template.repsValue,
+    repsMin: exerciseOrRef.repsMin ?? template.repsMin,
+    repsMax: exerciseOrRef.repsMax ?? template.repsMax,
+    repsUnit: exerciseOrRef.repsUnit ?? template.repsUnit,
+    repsPerSide: exerciseOrRef.repsPerSide ?? template.repsPerSide,
+    repsModifier: exerciseOrRef.repsModifier ?? template.repsModifier,
+    tempoEccentric: exerciseOrRef.tempoEccentric ?? template.tempoEccentric,
+    tempoPauseBottom: exerciseOrRef.tempoPauseBottom ?? template.tempoPauseBottom,
+    tempoConcentric: exerciseOrRef.tempoConcentric ?? template.tempoConcentric,
+    tempoPauseTop: exerciseOrRef.tempoPauseTop ?? template.tempoPauseTop,
+    isEmom: exerciseOrRef.isEmom ?? template.isEmom,
+    isUnilateral: exerciseOrRef.isUnilateral ?? template.isUnilateral,
+    supersetGroup: exerciseOrRef.supersetGroup ?? template.supersetGroup,
+  };
+
+  // Add cues if present
+  if (exerciseOrRef.cues ?? template.cues) {
+    (resolved as V2Exercise & { cues?: string[] }).cues = exerciseOrRef.cues ?? template.cues;
+  }
+
+  return resolved;
+}
+
+/**
+ * Resolve all exercises in an array, handling both full exercises and references (v2.2+)
+ */
+function resolveExercises(
+  exercises: (V2Exercise | V2ExerciseRef)[] | undefined,
+  exerciseTemplates: Map<string, V2ExerciseTemplate>
+): V2Exercise[] {
+  if (!exercises) return [];
+  return exercises.map(ex => resolveExerciseReference(ex, exerciseTemplates));
+}
+
+/**
  * Resolve a day reference to get the actual exercises
  * @param day - The day that may contain a $ref
  * @param dayTemplates - Array of day templates from the plan
  * @param dayRegistry - Registry of previously defined days by ID
+ * @param exerciseTemplates - Map of exercise templates by ID (v2.2+)
  * @returns The resolved exercises array, or null if not resolvable
  */
 function resolveDayReference(
   day: V2Day,
   dayTemplates: V2DayTemplate[] | undefined,
-  dayRegistry: Map<string, V2Exercise[]>
+  dayRegistry: Map<string, V2Exercise[]>,
+  exerciseTemplates: Map<string, V2ExerciseTemplate>
 ): V2Exercise[] | null {
-  // If day has exercises directly, return them
+  // If day has exercises directly, resolve any references and return them
   if (day.exercises && day.exercises.length > 0) {
-    return day.exercises;
+    return resolveExercises(day.exercises, exerciseTemplates);
   }
 
   // If day has a $ref, resolve it
@@ -440,7 +606,7 @@ function resolveDayReference(
     if (dayTemplates) {
       const template = dayTemplates.find(t => t.id === day.$ref);
       if (template) {
-        return template.exercises;
+        return resolveExercises(template.exercises, exerciseTemplates);
       }
     }
 
@@ -454,22 +620,30 @@ function resolveDayReference(
   }
 
   // Day has neither exercises nor $ref
-  return day.exercises ?? null;
+  return resolveExercises(day.exercises, exerciseTemplates);
 }
 
 /**
- * Convert v2.0.0/v2.1.0 structured format to internal schedule format
+ * Convert v2.0.0/v2.1.0/v2.2.0 structured format to internal schedule format
  * (Compatible with existing buildCompleteSchedule function)
- * @param v2Data - v2.0.0 or v2.1.0 format data
+ * @param v2Data - v2.0.0, v2.1.0, or v2.2.0 format data
  * @returns Internal schedule format (flat array for compatibility)
  * @throws Error if format is invalid
  */
 export function convertV2ToInternal(v2Data: unknown): InternalSchedule {
   if (!validateV2Format(v2Data)) {
-    throw new Error('Invalid v2.0.0/v2.1.0 workout plan format');
+    throw new Error('Invalid v2.0.0/v2.1.0/v2.2.0 workout plan format');
   }
 
   const internalFormat: ScheduleEntry[] = [];
+
+  // Build exercise templates map (v2.2+)
+  const exerciseTemplates = new Map<string, V2ExerciseTemplate>();
+  if (v2Data.plan.exerciseTemplates) {
+    for (const template of v2Data.plan.exerciseTemplates) {
+      exerciseTemplates.set(template.id, template);
+    }
+  }
 
   // Registry for day IDs to their exercises (for v2.1 references)
   const dayRegistry = new Map<string, V2Exercise[]>();
@@ -481,8 +655,8 @@ export function convertV2ToInternal(v2Data: unknown): InternalSchedule {
   v2Data.plan.phases.forEach((phase) => {
     phase.weeks.forEach((week) => {
       week.days.forEach((day) => {
-        // Resolve day references (v2.1 feature)
-        const exercises = resolveDayReference(day, dayTemplates, dayRegistry);
+        // Resolve day references (v2.1 feature) and exercise references (v2.2 feature)
+        const exercises = resolveDayReference(day, dayTemplates, dayRegistry, exerciseTemplates);
 
         // Register this day's exercises if it has an ID (for future references)
         if (day.id && exercises) {
@@ -860,8 +1034,8 @@ export function getPhaseForWeek(
 }
 
 /**
- * Get exercise details from v2.0.0 format
- * @param v2Data - v2.0.0 format data
+ * Get exercise details from v2.0.0/v2.1.0/v2.2.0 format
+ * @param v2Data - v2.0.0, v2.1.0, or v2.2.0 format data
  * @param weekNumber - Week number
  * @param dayNumber - Day number
  * @returns Array of exercise objects with full details, or null if not found
@@ -873,6 +1047,14 @@ export function getExercisesWithDetails(
 ): V2Exercise[] | null {
   if (!validateV2Format(v2Data)) {
     return null;
+  }
+
+  // Build exercise templates map (v2.2+)
+  const exerciseTemplates = new Map<string, V2ExerciseTemplate>();
+  if (v2Data.plan.exerciseTemplates) {
+    for (const template of v2Data.plan.exerciseTemplates) {
+      exerciseTemplates.set(template.id, template);
+    }
   }
 
   // Find the phase containing this week
@@ -890,7 +1072,8 @@ export function getExercisesWithDetails(
   const day = week.days.find((d) => d.dayNumber === dayNumber);
   if (!day) return null;
 
-  return day.exercises ?? null;
+  // Resolve exercise references (v2.2+)
+  return resolveExercises(day.exercises, exerciseTemplates);
 }
 
 /**

--- a/workout-plan-v2.2.json
+++ b/workout-plan-v2.2.json
@@ -1,0 +1,6729 @@
+{
+  "$schema": "./workout-plan-v2.2.schema.json",
+  "formatVersion": "2.2.0",
+  "plan": {
+    "id": "oneplus-12-pro-tracker-v1",
+    "name": "21-Week Calisthenics Strength Program",
+    "description": "Progressive bodyweight strength program focusing on pull-ups, dips, and fundamental calisthenics movements. Includes systematic progressions, skill work, and periodized training phases.",
+    "author": "OnePlus 12 Pro Tracker",
+    "createdDate": "2024-01-01",
+    "lastModified": "2025-11-30T20:08:11.214Z",
+    "version": "1.0.0",
+    "durationWeeks": 21,
+    "goals": [
+      "weighted-pull-ups",
+      "bodyweight-mastery",
+      "muscle-endurance",
+      "functional-strength",
+      "calisthenics-skills"
+    ],
+    "targetLevel": "intermediate",
+    "equipment": [
+      "pull-up-bar",
+      "rings",
+      "parallettes",
+      "dip-bars",
+      "resistance-bands",
+      "rower",
+      "dumbbells",
+      "barbell",
+      "bench",
+      "box"
+    ],
+    "programRules": {
+      "weeklyPullUpCap": {
+        "min": 36,
+        "max": 40,
+        "note": "Max weekly pull-up reps strictly capped per program rules (doc)."
+      },
+      "day5AccessoryTimeCapSeconds": 600,
+      "neutralGripTracking": {
+        "appliesTo": "Block 3 (weeks 9-12)",
+        "note": "Use the same neutral-grip implement (rings/parallel bars) for the whole block."
+      },
+      "dipGovernor": {
+        "appliesTo": "Block 4 (weeks 13-15)",
+        "rule": "If shoulder pinch occurs during weighted dips switch immediately to Straight Bar Dips or Weighted Bench Dips."
+      }
+    },
+    "phases": [
+      {
+        "phaseNumber": 1,
+        "name": "Foundation Phase",
+        "description": "Build base strength and establish movement patterns",
+        "startWeek": 1,
+        "endWeek": 4,
+        "focus": "volume",
+        "weeks": [
+          {
+            "weekNumber": 1,
+            "description": null,
+            "focus": null,
+            "volumeLevel": "moderate",
+            "intensityLevel": "moderate",
+            "days": [
+              {
+                "dayNumber": 1,
+                "name": "Pull Day A",
+                "type": "strength",
+                "estimatedDuration": 77,
+                "description": null,
+                "exercises": [
+                  {
+                    "$ref": "warmup-rower-zone1"
+                  },
+                  {
+                    "$ref": "warmup-rower-zone2"
+                  },
+                  {
+                    "$ref": "warmup-rower-sprints"
+                  },
+                  {
+                    "$ref": "warmup-band-pull-aparts"
+                  },
+                  {
+                    "$ref": "warmup-band-external-rotations"
+                  },
+                  {
+                    "$ref": "warmup-scapular-pullups"
+                  },
+                  {
+                    "$ref": "warmup-passive-bar-hang"
+                  },
+                  {
+                    "category": "skill",
+                    "sets": 3,
+                    "exerciseName": "Skill: Crow Stand",
+                    "notes": "Practice. Practice balance and wrist loading.",
+                    "repsType": "time",
+                    "repsMin": 10,
+                    "repsMax": 20,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 90
+                  },
+                  {
+                    "category": "main",
+                    "sets": 4,
+                    "exerciseName": "Pull-Up Ladders",
+                    "notes": "Volume. Ladders: 1, 2, 3 reps... Volume baseline. Focus on perfect form.",
+                    "repsType": "ladder",
+                    "repsValue": [
+                      1,
+                      2,
+                      3
+                    ],
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 120,
+                    "progressionNotes": "Volume accumulation phase. Do not fail sets."
+                  },
+                  {
+                    "category": "accessory",
+                    "sets": 3,
+                    "exerciseName": "Ring Rows",
+                    "notes": "Accessory. Tempo 2-1-1-0. Stop if sharp pain.",
+                    "repsType": "reps",
+                    "repsValue": 15,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60,
+                    "alternatives": [
+                      "Dumbbell Rows",
+                      "Cable Rows",
+                      "Inverted Rows"
+                    ]
+                  },
+                  {
+                    "category": "accessory",
+                    "sets": 3,
+                    "exerciseName": "Incline Push-Ups",
+                    "notes": "Accessory. Tempo 2-1-1-0.",
+                    "repsType": "reps",
+                    "repsValue": 10,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60,
+                    "alternatives": [
+                      "Dips",
+                      "Incline Push-Ups",
+                      "Diamond Push-Ups"
+                    ]
+                  },
+                  {
+                    "category": "core",
+                    "sets": 3,
+                    "exerciseName": "Hollow Rocks",
+                    "notes": "Core. Ground-Based. Watch for elbow tightness.",
+                    "repsType": "time",
+                    "repsValue": 25,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60,
+                    "alternatives": [
+                      "V-Ups",
+                      "Dead Bugs"
+                    ]
+                  },
+                  {
+                    "$ref": "cooldown-passive-dead-hang"
+                  },
+                  {
+                    "category": "cooldown",
+                    "sets": 1,
+                    "exerciseName": "Butcher’s Block Stretch",
+                    "notes": "Cool-down. Targeting Lats/Triceps.",
+                    "repsType": "time",
+                    "repsValue": 60,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 0
+                  },
+                  {
+                    "$ref": "cooldown-cobra-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-wrist-extensor"
+                  }
+                ]
+              },
+              {
+                "$ref": "template-mobility-recovery",
+                "dayNumber": 2
+              },
+              {
+                "dayNumber": 3,
+                "name": "Lower Body",
+                "type": "strength",
+                "estimatedDuration": 30,
+                "description": null,
+                "exercises": [
+                  {
+                    "category": "main",
+                    "sets": 4,
+                    "exerciseName": "RDL",
+                    "notes": "Posterior chain focus.",
+                    "loadMin": 85,
+                    "loadMax": 85,
+                    "loadUnit": "kg",
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "restSeconds": 120
+                  },
+                  {
+                    "category": "accessory",
+                    "sets": 3,
+                    "exerciseName": "Weighted Glute Bridge",
+                    "notes": "Accessory. Tempo 2-1-1-0. Squeeze glutes hard at top.",
+                    "loadMin": 40,
+                    "loadMax": 60,
+                    "loadUnit": "kg",
+                    "repsType": "reps",
+                    "repsMin": 10,
+                    "repsMax": 12,
+                    "restSeconds": 60,
+                    "cues": [
+                      "No lumbar hyperextension"
+                    ]
+                  },
+                  {
+                    "$ref": "main-goblet-squats",
+                    "notes": "Light/Tech. Reinforce healthy squat patterns. Ankle mobility focus."
+                  },
+                  {
+                    "$ref": "accessory-face-pulls",
+                    "repsMin": 15,
+                    "repsMax": 20
+                  },
+                  {
+                    "$ref": "cooldown-couch-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-jefferson-curl"
+                  },
+                  {
+                    "$ref": "cooldown-90-90-hip-rotations"
+                  }
+                ]
+              },
+              {
+                "dayNumber": 5,
+                "name": "Pull Day B",
+                "type": "strength",
+                "estimatedDuration": 76,
+                "description": null,
+                "exercises": [
+                  {
+                    "$ref": "warmup-rower-zone1"
+                  },
+                  {
+                    "$ref": "warmup-rower-zone2"
+                  },
+                  {
+                    "$ref": "warmup-rower-sprints"
+                  },
+                  {
+                    "$ref": "warmup-band-pull-aparts"
+                  },
+                  {
+                    "$ref": "warmup-band-external-rotations"
+                  },
+                  {
+                    "$ref": "warmup-scapular-pullups"
+                  },
+                  {
+                    "$ref": "warmup-passive-bar-hang"
+                  },
+                  {
+                    "category": "skill",
+                    "sets": 3,
+                    "exerciseName": "Skill: HSPU Volume",
+                    "notes": "Practice. Skill practice. Stop immediately if shoulder pinch occurs.",
+                    "repsType": "reps",
+                    "repsValue": 3,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 90
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Weighted Pull-Ups",
+                    "notes": "Primary Goal: Build elite pulling strength.",
+                    "loadMin": 8,
+                    "loadMax": 10,
+                    "loadUnit": "kg",
+                    "repsType": "reps",
+                    "repsValue": 5,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lat Pulldowns",
+                      "Ring Rows",
+                      "Assisted Pull-Ups"
+                    ],
+                    "progressionNotes": "DOUBLE PROGRESSION RULE: Earn weight increase only when hitting top rep range for ALL sets with perfect form. (e.g. if 3x5 is goal, must hit 5,5,5 to add 1kg).",
+                    "cues": [
+                      "Full ROM",
+                      "Chin over bar",
+                      "Controlled descent"
+                    ]
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Dips",
+                    "notes": "Dip Governor Rule: If shoulder pinch occurs, switch immediately.",
+                    "repsType": "reps",
+                    "repsValue": 10,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Push-Ups",
+                      "Bench Dips",
+                      "Chest Press Machine"
+                    ],
+                    "progressionNotes": "Double Progression Rule applies.",
+                    "cues": [
+                      "Shoulders down",
+                      "Don't flair elbows"
+                    ]
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Bulgarian Split Squat",
+                    "notes": "Left side. EMOM. Unilateral Leg Work: Use Alternating EMOM (Min 1 Left, Min 2 Right).",
+                    "loadMin": 8,
+                    "loadMax": 16,
+                    "loadUnit": "kg",
+                    "loadPerHand": true,
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "isEmom": true,
+                    "supersetGroup": 1,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lunges",
+                      "Step-Ups",
+                      "Split Squats"
+                    ],
+                    "cues": [
+                      "Vertical shin",
+                      "Drive through heel"
+                    ],
+                    "isUnilateral": true
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Bulgarian Split Squat",
+                    "notes": "Right side. EMOM. Unilateral Leg Work: Use Alternating EMOM (Min 1 Left, Min 2 Right).",
+                    "loadMin": 8,
+                    "loadMax": 16,
+                    "loadUnit": "kg",
+                    "loadPerHand": true,
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "isEmom": true,
+                    "supersetGroup": 1,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lunges",
+                      "Step-Ups",
+                      "Split Squats"
+                    ],
+                    "cues": [
+                      "Vertical shin",
+                      "Drive through heel"
+                    ],
+                    "isUnilateral": true
+                  },
+                  {
+                    "$ref": "core-weighted-hollow-rocks",
+                    "category": "main",
+                    "restSeconds": 120,
+                    "notes": "EMOM. Arms straight overhead. If lower back arches, drop weight immediately.",
+                    "isEmom": true,
+                    "supersetGroup": 1
+                  },
+                  {
+                    "$ref": "cooldown-banded-pec-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-lat-prayer"
+                  },
+                  {
+                    "$ref": "cooldown-standing-quad-stretch"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "weekNumber": 2,
+            "description": null,
+            "focus": null,
+            "volumeLevel": "high",
+            "intensityLevel": "moderate",
+            "days": [
+              {
+                "dayNumber": 1,
+                "name": "Pull Day A",
+                "type": "strength",
+                "estimatedDuration": 60,
+                "description": null,
+                "exercises": [
+                  {
+                    "$ref": "warmup-rower-zone1"
+                  },
+                  {
+                    "$ref": "warmup-rower-zone2"
+                  },
+                  {
+                    "$ref": "warmup-rower-sprints"
+                  },
+                  {
+                    "$ref": "warmup-band-pull-aparts"
+                  },
+                  {
+                    "$ref": "warmup-band-external-rotations"
+                  },
+                  {
+                    "$ref": "warmup-scapular-pullups"
+                  },
+                  {
+                    "$ref": "warmup-passive-bar-hang"
+                  },
+                  {
+                    "category": "main",
+                    "sets": 5,
+                    "exerciseName": "Pull-Up Ladders",
+                    "notes": "Volume Increase. Ladders: 1, 2, 3 reps... Volume baseline. Focus on perfect form.",
+                    "repsType": "ladder",
+                    "repsValue": [
+                      1,
+                      2,
+                      3
+                    ],
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 120,
+                    "progressionNotes": "Volume accumulation phase. Do not fail sets."
+                  },
+                  {
+                    "category": "accessory",
+                    "sets": 3,
+                    "exerciseName": "Ring Rows",
+                    "notes": "Accessory. Tempo 2-1-1-0. Stop if sharp pain.",
+                    "repsType": "reps",
+                    "repsValue": 15,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60,
+                    "alternatives": [
+                      "Dumbbell Rows",
+                      "Cable Rows",
+                      "Inverted Rows"
+                    ]
+                  },
+                  {
+                    "category": "accessory",
+                    "sets": 3,
+                    "exerciseName": "Incline Push-Ups",
+                    "notes": "Accessory. Tempo 2-1-1-0.",
+                    "repsType": "reps",
+                    "repsValue": 10,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60,
+                    "alternatives": [
+                      "Dips",
+                      "Diamond Push-Ups"
+                    ]
+                  },
+                  {
+                    "category": "core",
+                    "sets": 3,
+                    "exerciseName": "Hollow Rocks",
+                    "notes": "Core. Ground-Based. Watch for elbow tightness.",
+                    "repsType": "time",
+                    "repsValue": 25,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60,
+                    "alternatives": [
+                      "V-Ups",
+                      "Dead Bugs"
+                    ]
+                  },
+                  {
+                    "$ref": "cooldown-passive-dead-hang"
+                  },
+                  {
+                    "category": "cooldown",
+                    "sets": 1,
+                    "exerciseName": "Butcher’s Block Stretch",
+                    "notes": "Cool-down. Targeting Lats/Triceps.",
+                    "repsType": "time",
+                    "repsValue": 60,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 0
+                  },
+                  {
+                    "$ref": "cooldown-cobra-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-wrist-extensor"
+                  }
+                ]
+              },
+              {
+                "$ref": "template-mobility-recovery",
+                "dayNumber": 2
+              },
+              {
+                "dayNumber": 3,
+                "name": "Lower Body",
+                "type": "strength",
+                "estimatedDuration": 30,
+                "description": null,
+                "exercises": [
+                  {
+                    "category": "main",
+                    "sets": 4,
+                    "exerciseName": "RDL",
+                    "notes": "Posterior chain focus.",
+                    "loadMin": 85,
+                    "loadMax": 85,
+                    "loadUnit": "kg",
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "restSeconds": 120
+                  },
+                  {
+                    "category": "accessory",
+                    "sets": 3,
+                    "exerciseName": "Weighted Glute Bridge",
+                    "notes": "Accessory. Tempo 2-1-1-0. Squeeze glutes hard at top.",
+                    "loadMin": 40,
+                    "loadMax": 60,
+                    "loadUnit": "kg",
+                    "repsType": "reps",
+                    "repsMin": 10,
+                    "repsMax": 12,
+                    "restSeconds": 60,
+                    "cues": [
+                      "No lumbar hyperextension"
+                    ]
+                  },
+                  {
+                    "$ref": "main-goblet-squats",
+                    "notes": "Moderate. Reinforce healthy squat patterns. Ankle mobility focus.",
+                    "repsValue": 12
+                  },
+                  {
+                    "$ref": "accessory-face-pulls",
+                    "repsMin": 15,
+                    "repsMax": 20
+                  },
+                  {
+                    "$ref": "cooldown-couch-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-jefferson-curl"
+                  },
+                  {
+                    "$ref": "cooldown-90-90-hip-rotations"
+                  }
+                ]
+              },
+              {
+                "dayNumber": 5,
+                "name": "Pull Day B",
+                "type": "strength",
+                "estimatedDuration": 57,
+                "description": null,
+                "exercises": [
+                  {
+                    "$ref": "warmup-rower-zone1"
+                  },
+                  {
+                    "$ref": "warmup-rower-zone2"
+                  },
+                  {
+                    "$ref": "warmup-rower-sprints"
+                  },
+                  {
+                    "$ref": "warmup-band-pull-aparts"
+                  },
+                  {
+                    "$ref": "warmup-band-external-rotations"
+                  },
+                  {
+                    "$ref": "warmup-scapular-pullups"
+                  },
+                  {
+                    "$ref": "warmup-passive-bar-hang"
+                  },
+                  {
+                    "category": "main",
+                    "sets": 2,
+                    "exerciseName": "Weighted Pull-Ups",
+                    "notes": "Primary Goal: Build elite pulling strength.",
+                    "loadMin": 9,
+                    "loadMax": 11,
+                    "loadUnit": "kg",
+                    "repsType": "reps",
+                    "repsValue": 5,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lat Pulldowns",
+                      "Ring Rows",
+                      "Assisted Pull-Ups"
+                    ],
+                    "progressionNotes": "DOUBLE PROGRESSION RULE: Earn weight increase only when hitting top rep range for ALL sets with perfect form. (e.g. if 3x5 is goal, must hit 5,5,5 to add 1kg).",
+                    "cues": [
+                      "Full ROM",
+                      "Chin over bar",
+                      "Controlled descent"
+                    ]
+                  },
+                  {
+                    "category": "core",
+                    "sets": 3,
+                    "exerciseName": "Ground-Based Flutter Kicks",
+                    "notes": "Core Recovery. Core recovery.",
+                    "repsType": "time",
+                    "repsValue": 30,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Dips",
+                    "notes": "Dip Governor Rule: If shoulder pinch occurs, switch immediately.",
+                    "repsType": "reps",
+                    "repsValue": 10,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Push-Ups",
+                      "Bench Dips",
+                      "Chest Press Machine"
+                    ],
+                    "progressionNotes": "Double Progression Rule applies.",
+                    "cues": [
+                      "Shoulders down",
+                      "Don't flair elbows"
+                    ]
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Bulgarian Split Squat",
+                    "notes": "Left side. EMOM. Unilateral Leg Work.",
+                    "loadMin": 8,
+                    "loadMax": 16,
+                    "loadUnit": "kg",
+                    "loadPerHand": true,
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "isEmom": true,
+                    "supersetGroup": 1,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lunges",
+                      "Step-Ups",
+                      "Split Squats"
+                    ],
+                    "cues": [
+                      "Vertical shin",
+                      "Drive through heel"
+                    ],
+                    "isUnilateral": true
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Bulgarian Split Squat",
+                    "notes": "Right side. EMOM. Unilateral Leg Work.",
+                    "loadMin": 8,
+                    "loadMax": 16,
+                    "loadUnit": "kg",
+                    "loadPerHand": true,
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "isEmom": true,
+                    "supersetGroup": 1,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lunges",
+                      "Step-Ups",
+                      "Split Squats"
+                    ],
+                    "cues": [
+                      "Vertical shin",
+                      "Drive through heel"
+                    ],
+                    "isUnilateral": true
+                  },
+                  {
+                    "$ref": "cooldown-banded-pec-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-lat-prayer"
+                  },
+                  {
+                    "$ref": "cooldown-standing-quad-stretch"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "weekNumber": 3,
+            "description": null,
+            "focus": null,
+            "volumeLevel": "high",
+            "intensityLevel": "high",
+            "days": [
+              {
+                "dayNumber": 1,
+                "name": "Pull Day A",
+                "type": "strength",
+                "estimatedDuration": 60,
+                "description": null,
+                "exercises": [
+                  {
+                    "$ref": "warmup-rower-zone1"
+                  },
+                  {
+                    "$ref": "warmup-rower-zone2"
+                  },
+                  {
+                    "$ref": "warmup-rower-sprints"
+                  },
+                  {
+                    "$ref": "warmup-band-pull-aparts"
+                  },
+                  {
+                    "$ref": "warmup-band-external-rotations"
+                  },
+                  {
+                    "$ref": "warmup-scapular-pullups"
+                  },
+                  {
+                    "$ref": "warmup-passive-bar-hang"
+                  },
+                  {
+                    "category": "main",
+                    "sets": 5,
+                    "exerciseName": "Pull-Up Ladders",
+                    "notes": "Volume Peak. Ladders: 1, 2, 3 reps... Volume baseline. Focus on perfect form.",
+                    "repsType": "ladder",
+                    "repsValue": [
+                      1,
+                      2,
+                      3
+                    ],
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 120,
+                    "progressionNotes": "Volume accumulation phase. Do not fail sets."
+                  },
+                  {
+                    "category": "accessory",
+                    "sets": 3,
+                    "exerciseName": "Ring Rows",
+                    "notes": "Accessory. Tempo 2-1-1-0. Stop if sharp pain.",
+                    "repsType": "reps",
+                    "repsValue": 15,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60,
+                    "alternatives": [
+                      "Dumbbell Rows",
+                      "Cable Rows",
+                      "Inverted Rows"
+                    ]
+                  },
+                  {
+                    "category": "accessory",
+                    "sets": 3,
+                    "exerciseName": "Incline Push-Ups",
+                    "notes": "Accessory. Tempo 2-1-1-0.",
+                    "repsType": "reps",
+                    "repsValue": 10,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60,
+                    "alternatives": [
+                      "Dips",
+                      "Diamond Push-Ups"
+                    ]
+                  },
+                  {
+                    "category": "core",
+                    "sets": 3,
+                    "exerciseName": "Hollow Rocks",
+                    "notes": "Core. Ground-Based. Watch for elbow tightness.",
+                    "repsType": "time",
+                    "repsValue": 25,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60,
+                    "alternatives": [
+                      "V-Ups",
+                      "Dead Bugs"
+                    ]
+                  },
+                  {
+                    "$ref": "cooldown-passive-dead-hang"
+                  },
+                  {
+                    "category": "cooldown",
+                    "sets": 1,
+                    "exerciseName": "Butcher’s Block Stretch",
+                    "notes": "Cool-down. Targeting Lats/Triceps.",
+                    "repsType": "time",
+                    "repsValue": 60,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 0
+                  },
+                  {
+                    "$ref": "cooldown-cobra-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-wrist-extensor"
+                  }
+                ]
+              },
+              {
+                "$ref": "template-mobility-recovery",
+                "dayNumber": 2
+              },
+              {
+                "dayNumber": 3,
+                "name": "Lower Body",
+                "type": "strength",
+                "estimatedDuration": 30,
+                "description": null,
+                "exercises": [
+                  {
+                    "category": "main",
+                    "sets": 4,
+                    "exerciseName": "RDL",
+                    "notes": "Posterior chain focus.",
+                    "loadMin": 85,
+                    "loadMax": 85,
+                    "loadUnit": "kg",
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "restSeconds": 120
+                  },
+                  {
+                    "category": "accessory",
+                    "sets": 3,
+                    "exerciseName": "Weighted Glute Bridge",
+                    "notes": "Accessory. Tempo 2-1-1-0. Squeeze glutes hard at top.",
+                    "loadMin": 40,
+                    "loadMax": 60,
+                    "loadUnit": "kg",
+                    "repsType": "reps",
+                    "repsMin": 10,
+                    "repsMax": 12,
+                    "restSeconds": 60,
+                    "cues": [
+                      "No lumbar hyperextension"
+                    ]
+                  },
+                  {
+                    "$ref": "main-goblet-squats",
+                    "notes": "Heavy. Reinforce healthy squat patterns. Ankle mobility focus.",
+                    "loadMin": 24,
+                    "loadMax": 32
+                  },
+                  {
+                    "$ref": "accessory-face-pulls",
+                    "repsMin": 15,
+                    "repsMax": 20
+                  },
+                  {
+                    "$ref": "cooldown-couch-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-jefferson-curl"
+                  },
+                  {
+                    "$ref": "cooldown-90-90-hip-rotations"
+                  }
+                ]
+              },
+              {
+                "dayNumber": 5,
+                "name": "Pull Day B",
+                "type": "strength",
+                "estimatedDuration": 57,
+                "description": null,
+                "exercises": [
+                  {
+                    "$ref": "warmup-rower-zone1"
+                  },
+                  {
+                    "$ref": "warmup-rower-zone2"
+                  },
+                  {
+                    "$ref": "warmup-rower-sprints"
+                  },
+                  {
+                    "$ref": "warmup-band-pull-aparts"
+                  },
+                  {
+                    "$ref": "warmup-band-external-rotations"
+                  },
+                  {
+                    "$ref": "warmup-scapular-pullups"
+                  },
+                  {
+                    "$ref": "warmup-passive-bar-hang"
+                  },
+                  {
+                    "category": "main",
+                    "sets": 2,
+                    "exerciseName": "Weighted Pull-Ups",
+                    "notes": "Primary Goal: Build elite pulling strength.",
+                    "loadMin": 10,
+                    "loadMax": 12,
+                    "loadUnit": "kg",
+                    "repsType": "reps",
+                    "repsValue": 5,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lat Pulldowns",
+                      "Ring Rows",
+                      "Assisted Pull-Ups"
+                    ],
+                    "progressionNotes": "DOUBLE PROGRESSION RULE: Earn weight increase only when hitting top rep range for ALL sets with perfect form. (e.g. if 3x5 is goal, must hit 5,5,5 to add 1kg).",
+                    "cues": [
+                      "Full ROM",
+                      "Chin over bar",
+                      "Controlled descent"
+                    ]
+                  },
+                  {
+                    "category": "core",
+                    "sets": 3,
+                    "exerciseName": "Weighted V-Ups",
+                    "notes": "Core Hard. Hard Core. Keep biceps by ears.",
+                    "loadMin": 3,
+                    "loadMax": 5,
+                    "loadUnit": "kg",
+                    "repsType": "reps",
+                    "repsMin": 10,
+                    "repsMax": 12,
+                    "restSeconds": 60,
+                    "progressionNotes": "Start 1.25kg. Progress only with perfect form."
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Dips",
+                    "notes": "Dip Governor Rule: If shoulder pinch occurs, switch immediately.",
+                    "repsType": "reps",
+                    "repsValue": 10,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Push-Ups",
+                      "Bench Dips",
+                      "Chest Press Machine"
+                    ],
+                    "progressionNotes": "Double Progression Rule applies.",
+                    "cues": [
+                      "Shoulders down",
+                      "Don't flair elbows"
+                    ]
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Bulgarian Split Squat",
+                    "notes": "Left side. EMOM. Unilateral Leg Work.",
+                    "loadMin": 8,
+                    "loadMax": 16,
+                    "loadUnit": "kg",
+                    "loadPerHand": true,
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "isEmom": true,
+                    "supersetGroup": 1,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lunges",
+                      "Step-Ups",
+                      "Split Squats"
+                    ],
+                    "cues": [
+                      "Vertical shin",
+                      "Drive through heel"
+                    ],
+                    "isUnilateral": true
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Bulgarian Split Squat",
+                    "notes": "Right side. EMOM. Unilateral Leg Work.",
+                    "loadMin": 8,
+                    "loadMax": 16,
+                    "loadUnit": "kg",
+                    "loadPerHand": true,
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "isEmom": true,
+                    "supersetGroup": 1,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lunges",
+                      "Step-Ups",
+                      "Split Squats"
+                    ],
+                    "cues": [
+                      "Vertical shin",
+                      "Drive through heel"
+                    ],
+                    "isUnilateral": true
+                  },
+                  {
+                    "$ref": "cooldown-banded-pec-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-lat-prayer"
+                  },
+                  {
+                    "$ref": "cooldown-standing-quad-stretch"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "weekNumber": 4,
+            "description": null,
+            "focus": null,
+            "volumeLevel": "low",
+            "intensityLevel": "low",
+            "days": [
+              {
+                "dayNumber": 1,
+                "name": "Pull Day A",
+                "type": "strength",
+                "estimatedDuration": 57,
+                "description": null,
+                "exercises": [
+                  {
+                    "$ref": "warmup-rower-zone1"
+                  },
+                  {
+                    "$ref": "warmup-rower-zone2"
+                  },
+                  {
+                    "$ref": "warmup-rower-sprints"
+                  },
+                  {
+                    "$ref": "warmup-band-pull-aparts"
+                  },
+                  {
+                    "$ref": "warmup-band-external-rotations"
+                  },
+                  {
+                    "$ref": "warmup-scapular-pullups"
+                  },
+                  {
+                    "$ref": "warmup-passive-bar-hang"
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Pull-Up Ladders",
+                    "notes": "Deload Volume. Ladders: 1, 2, 3 reps... Volume baseline. Focus on perfect form.",
+                    "repsType": "ladder",
+                    "repsValue": [
+                      1,
+                      2,
+                      3
+                    ],
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 120,
+                    "progressionNotes": "Volume accumulation phase. Do not fail sets."
+                  },
+                  {
+                    "category": "accessory",
+                    "sets": 2,
+                    "exerciseName": "Ring Rows",
+                    "notes": "Deload. Accessory. Tempo 2-1-1-0. Stop if sharp pain.",
+                    "repsType": "reps",
+                    "repsValue": 15,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60,
+                    "alternatives": [
+                      "Dumbbell Rows",
+                      "Cable Rows",
+                      "Inverted Rows"
+                    ]
+                  },
+                  {
+                    "category": "accessory",
+                    "sets": 2,
+                    "exerciseName": "Incline Push-Ups",
+                    "notes": "Deload. Accessory. Tempo 2-1-1-0.",
+                    "repsType": "reps",
+                    "repsValue": 10,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60,
+                    "alternatives": [
+                      "Dips",
+                      "Diamond Push-Ups"
+                    ]
+                  },
+                  {
+                    "category": "core",
+                    "sets": 2,
+                    "exerciseName": "Hollow Rocks",
+                    "notes": "Deload. Core. Ground-Based. Watch for elbow tightness.",
+                    "repsType": "time",
+                    "repsValue": 25,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60,
+                    "alternatives": [
+                      "V-Ups",
+                      "Dead Bugs"
+                    ]
+                  },
+                  {
+                    "$ref": "cooldown-passive-dead-hang"
+                  },
+                  {
+                    "category": "cooldown",
+                    "sets": 1,
+                    "exerciseName": "Butcher’s Block Stretch",
+                    "notes": "Cool-down. Targeting Lats/Triceps.",
+                    "repsType": "time",
+                    "repsValue": 60,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 0
+                  },
+                  {
+                    "$ref": "cooldown-cobra-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-wrist-extensor"
+                  }
+                ]
+              },
+              {
+                "$ref": "template-mobility-recovery",
+                "dayNumber": 2
+              },
+              {
+                "dayNumber": 3,
+                "name": "Lower Body",
+                "type": "strength",
+                "estimatedDuration": 20,
+                "description": "Deload focus on light Goblet Squats and recovery work.",
+                "exercises": [
+                  {
+                    "$ref": "main-goblet-squats",
+                    "sets": 2,
+                    "notes": "Deload. Reinforce healthy squat patterns with light load. Focus on ankle mobility and tempo control.",
+                    "loadMin": 12,
+                    "loadMax": 16
+                  },
+                  {
+                    "$ref": "cooldown-couch-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-jefferson-curl"
+                  },
+                  {
+                    "$ref": "cooldown-90-90-hip-rotations"
+                  }
+                ]
+              },
+              {
+                "dayNumber": 5,
+                "name": "Pull Day B",
+                "type": "strength",
+                "estimatedDuration": 52,
+                "description": null,
+                "exercises": [
+                  {
+                    "$ref": "warmup-rower-zone1"
+                  },
+                  {
+                    "$ref": "warmup-rower-zone2"
+                  },
+                  {
+                    "$ref": "warmup-rower-sprints"
+                  },
+                  {
+                    "$ref": "warmup-band-pull-aparts"
+                  },
+                  {
+                    "$ref": "warmup-band-external-rotations"
+                  },
+                  {
+                    "$ref": "warmup-scapular-pullups"
+                  },
+                  {
+                    "$ref": "warmup-passive-bar-hang"
+                  },
+                  {
+                    "category": "main",
+                    "sets": 2,
+                    "exerciseName": "Weighted Pull-Ups",
+                    "notes": "50% (Easy). Primary Goal: Build elite pulling strength.",
+                    "loadMin": 5,
+                    "loadMax": 10,
+                    "loadUnit": "kg",
+                    "repsType": "reps",
+                    "repsValue": 3,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lat Pulldowns",
+                      "Ring Rows",
+                      "Assisted Pull-Ups"
+                    ],
+                    "progressionNotes": "DOUBLE PROGRESSION RULE: Earn weight increase only when hitting top rep range for ALL sets with perfect form. (e.g. if 3x5 is goal, must hit 5,5,5 to add 1kg).",
+                    "cues": [
+                      "Full ROM",
+                      "Chin over bar",
+                      "Controlled descent"
+                    ]
+                  },
+                  {
+                    "category": "main",
+                    "sets": 2,
+                    "exerciseName": "Dips",
+                    "notes": "Deload. Dip Governor Rule: If shoulder pinch occurs, switch immediately.",
+                    "repsType": "reps",
+                    "repsValue": 10,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Push-Ups",
+                      "Bench Dips",
+                      "Chest Press Machine"
+                    ],
+                    "progressionNotes": "Double Progression Rule applies.",
+                    "cues": [
+                      "Shoulders down",
+                      "Don't flair elbows"
+                    ]
+                  },
+                  {
+                    "category": "main",
+                    "sets": 2,
+                    "exerciseName": "Bulgarian Split Squat",
+                    "notes": "Left side. Deload. EMOM. Unilateral Leg Work.",
+                    "loadMin": 8,
+                    "loadMax": 16,
+                    "loadUnit": "kg",
+                    "loadPerHand": true,
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "isEmom": true,
+                    "supersetGroup": 1,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lunges",
+                      "Step-Ups",
+                      "Split Squats"
+                    ],
+                    "cues": [
+                      "Vertical shin",
+                      "Drive through heel"
+                    ],
+                    "isUnilateral": true
+                  },
+                  {
+                    "category": "main",
+                    "sets": 2,
+                    "exerciseName": "Bulgarian Split Squat",
+                    "notes": "Right side. Deload. EMOM. Unilateral Leg Work.",
+                    "loadMin": 8,
+                    "loadMax": 16,
+                    "loadUnit": "kg",
+                    "loadPerHand": true,
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "isEmom": true,
+                    "supersetGroup": 1,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lunges",
+                      "Step-Ups",
+                      "Split Squats"
+                    ],
+                    "cues": [
+                      "Vertical shin",
+                      "Drive through heel"
+                    ],
+                    "isUnilateral": true
+                  },
+                  {
+                    "$ref": "cooldown-banded-pec-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-lat-prayer"
+                  },
+                  {
+                    "$ref": "cooldown-standing-quad-stretch"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "phaseNumber": 2,
+        "name": "Development Phase",
+        "description": "Increase training intensity and volume",
+        "startWeek": 5,
+        "endWeek": 8,
+        "focus": "intensity",
+        "weeks": [
+          {
+            "weekNumber": 5,
+            "description": null,
+            "focus": null,
+            "volumeLevel": "moderate",
+            "intensityLevel": "moderate",
+            "days": [
+              {
+                "dayNumber": 1,
+                "name": "Pull Day A",
+                "type": "strength",
+                "estimatedDuration": 78,
+                "description": null,
+                "exercises": [
+                  {
+                    "$ref": "warmup-rower-zone1"
+                  },
+                  {
+                    "$ref": "warmup-rower-zone2"
+                  },
+                  {
+                    "$ref": "warmup-rower-sprints"
+                  },
+                  {
+                    "$ref": "warmup-band-pull-aparts"
+                  },
+                  {
+                    "$ref": "warmup-band-external-rotations"
+                  },
+                  {
+                    "$ref": "warmup-scapular-pullups"
+                  },
+                  {
+                    "$ref": "warmup-passive-bar-hang"
+                  },
+                  {
+                    "category": "skill",
+                    "sets": 3,
+                    "exerciseName": "Skill: Tuck Planche Hold",
+                    "notes": "Practice. Protracted scapula (pushed apart) and depressed. Knees to chest.",
+                    "repsType": "time",
+                    "repsMin": 6,
+                    "repsMax": 8,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 90,
+                    "cues": [
+                      "Arms straight",
+                      "Scapula protracted",
+                      "Knees tight"
+                    ]
+                  },
+                  {
+                    "category": "main",
+                    "sets": 8,
+                    "exerciseName": "Pull-Up EMOM",
+                    "notes": "Density. Perform reps at the start of every minute.",
+                    "repsType": "reps",
+                    "repsValue": 4,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "isEmom": true,
+                    "restSeconds": 120
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Feet-Elevated Ring Rows",
+                    "notes": "Tempo 2-1-1-0. Stop if sharp pain.",
+                    "repsType": "reps",
+                    "repsValue": 10,
+                    "tempoEccentric": 2,
+                    "tempoPauseBottom": 1,
+                    "tempoConcentric": 1,
+                    "tempoPauseTop": 0,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Dumbbell Rows",
+                      "Cable Rows",
+                      "Inverted Rows"
+                    ]
+                  },
+                  {
+                    "category": "accessory",
+                    "sets": 3,
+                    "exerciseName": "Parallette Push-Ups",
+                    "notes": "Accessory. Deep range of motion.",
+                    "repsType": "reps",
+                    "repsValue": 10,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60,
+                    "alternatives": [
+                      "Dips",
+                      "Incline Push-Ups",
+                      "Diamond Push-Ups"
+                    ]
+                  },
+                  {
+                    "category": "core",
+                    "sets": 3,
+                    "exerciseName": "Hollow Rocks",
+                    "notes": "Core. Ground-Based. Watch for elbow tightness.",
+                    "repsType": "time",
+                    "repsValue": 25,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60,
+                    "alternatives": [
+                      "V-Ups",
+                      "Dead Bugs"
+                    ]
+                  },
+                  {
+                    "$ref": "cooldown-passive-dead-hang"
+                  },
+                  {
+                    "category": "cooldown",
+                    "sets": 1,
+                    "exerciseName": "Butcher’s Block Stretch",
+                    "notes": "Cool-down. Targeting Lats/Triceps.",
+                    "repsType": "time",
+                    "repsValue": 60,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 0
+                  },
+                  {
+                    "$ref": "cooldown-cobra-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-wrist-extensor"
+                  }
+                ]
+              },
+              {
+                "$ref": "template-mobility-recovery",
+                "dayNumber": 2
+              },
+              {
+                "$ref": "template-lower-body",
+                "dayNumber": 3
+              },
+              {
+                "dayNumber": 5,
+                "name": "Pull Day B",
+                "type": "strength",
+                "estimatedDuration": 75,
+                "description": null,
+                "exercises": [
+                  {
+                    "$ref": "warmup-rower-zone1"
+                  },
+                  {
+                    "$ref": "warmup-rower-zone2"
+                  },
+                  {
+                    "$ref": "warmup-rower-sprints"
+                  },
+                  {
+                    "$ref": "warmup-band-pull-aparts"
+                  },
+                  {
+                    "$ref": "warmup-band-external-rotations"
+                  },
+                  {
+                    "$ref": "warmup-scapular-pullups"
+                  },
+                  {
+                    "$ref": "warmup-passive-bar-hang"
+                  },
+                  {
+                    "category": "skill",
+                    "sets": 3,
+                    "exerciseName": "Skill: PPPU Lean",
+                    "notes": "Practice. Pseudo Planche Push Up. Maintain scapular protraction throughout.",
+                    "repsType": "none",
+                    "repsValue": null,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 90,
+                    "cues": [
+                      "Lean forward",
+                      "Glutes squeezed"
+                    ]
+                  },
+                  {
+                    "category": "main",
+                    "sets": 2,
+                    "exerciseName": "Weighted Pull-Ups",
+                    "notes": "Primary Goal: Build elite pulling strength.",
+                    "loadMin": 10,
+                    "loadMax": 10,
+                    "loadUnit": "kg",
+                    "repsType": "reps",
+                    "repsValue": 4,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lat Pulldowns",
+                      "Ring Rows",
+                      "Assisted Pull-Ups"
+                    ],
+                    "progressionNotes": "DOUBLE PROGRESSION RULE: Earn weight increase only when hitting top rep range for ALL sets with perfect form. (e.g. if 3x5 is goal, must hit 5,5,5 to add 1kg).",
+                    "cues": [
+                      "Full ROM",
+                      "Chin over bar",
+                      "Controlled descent"
+                    ]
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Weighted Dips",
+                    "notes": "Double Progression. Dip Governor Rule: If shoulder pinch occurs, switch immediately.",
+                    "loadMin": 5,
+                    "loadMax": 10,
+                    "loadUnit": "kg",
+                    "repsType": "reps",
+                    "repsValue": 5,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Push-Ups",
+                      "Bench Dips",
+                      "Chest Press Machine"
+                    ],
+                    "progressionNotes": "Double Progression Rule: Hit top reps to add weight."
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Bulgarian Split Squat",
+                    "notes": "Left side. EMOM. Unilateral Leg Work: Use Alternating EMOM (Min 1 Left, Min 2 Right).",
+                    "loadMin": 8,
+                    "loadMax": 16,
+                    "loadUnit": "kg",
+                    "loadPerHand": true,
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "isEmom": true,
+                    "supersetGroup": 3,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lunges",
+                      "Step-Ups",
+                      "Split Squats"
+                    ],
+                    "cues": [
+                      "Vertical shin",
+                      "Drive through heel"
+                    ],
+                    "isUnilateral": true
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Bulgarian Split Squat",
+                    "notes": "Right side. EMOM. Unilateral Leg Work: Use Alternating EMOM (Min 1 Left, Min 2 Right).",
+                    "loadMin": 8,
+                    "loadMax": 16,
+                    "loadUnit": "kg",
+                    "loadPerHand": true,
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "isEmom": true,
+                    "supersetGroup": 3,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lunges",
+                      "Step-Ups",
+                      "Split Squats"
+                    ],
+                    "cues": [
+                      "Vertical shin",
+                      "Drive through heel"
+                    ],
+                    "isUnilateral": true
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Weighted Hollow Rocks",
+                    "notes": "EMOM. Arms straight overhead. If lower back arches, drop weight immediately.",
+                    "loadMin": 3,
+                    "loadMax": 5,
+                    "loadUnit": "kg",
+                    "repsType": "reps",
+                    "repsValue": 15,
+                    "isEmom": true,
+                    "supersetGroup": 3,
+                    "restSeconds": 120,
+                    "progressionNotes": "Start 1.25/2.5kg. Move to 5kg only when holding shape perfectly for 45s."
+                  },
+                  {
+                    "$ref": "cooldown-banded-pec-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-lat-prayer"
+                  },
+                  {
+                    "$ref": "cooldown-standing-quad-stretch"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "weekNumber": 6,
+            "description": null,
+            "focus": null,
+            "volumeLevel": "high",
+            "intensityLevel": "moderate",
+            "days": [
+              {
+                "dayNumber": 1,
+                "name": "Pull Day A",
+                "type": "strength",
+                "estimatedDuration": 66,
+                "description": null,
+                "exercises": [
+                  {
+                    "$ref": "warmup-rower-zone1"
+                  },
+                  {
+                    "$ref": "warmup-rower-zone2"
+                  },
+                  {
+                    "$ref": "warmup-rower-sprints"
+                  },
+                  {
+                    "$ref": "warmup-band-pull-aparts"
+                  },
+                  {
+                    "$ref": "warmup-band-external-rotations"
+                  },
+                  {
+                    "$ref": "warmup-scapular-pullups"
+                  },
+                  {
+                    "$ref": "warmup-passive-bar-hang"
+                  },
+                  {
+                    "category": "main",
+                    "sets": 9,
+                    "exerciseName": "Pull-Up EMOM",
+                    "notes": "Volume Peak. Perform reps at the start of every minute.",
+                    "repsType": "reps",
+                    "repsValue": 4,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "isEmom": true,
+                    "restSeconds": 120
+                  },
+                  {
+                    "category": "accessory",
+                    "sets": 3,
+                    "exerciseName": "Feet-Elevated Ring Rows",
+                    "notes": "Accessory. Tempo 2-1-1-0. Feet elevated for increased difficulty.",
+                    "repsType": "reps",
+                    "repsValue": 12,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60,
+                    "alternatives": [
+                      "Ring Rows",
+                      "Dumbbell Rows"
+                    ]
+                  },
+                  {
+                    "category": "accessory",
+                    "sets": 3,
+                    "exerciseName": "Parallette Push-Ups",
+                    "notes": "Accessory. Tempo 2-1-1-0. Increased ROM.",
+                    "repsType": "reps",
+                    "repsValue": 10,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60,
+                    "alternatives": [
+                      "Push-Ups",
+                      "Diamond Push-Ups"
+                    ]
+                  },
+                  {
+                    "category": "core",
+                    "sets": 3,
+                    "exerciseName": "Hollow Rocks",
+                    "notes": "Core. Ground-Based. Watch for elbow tightness.",
+                    "repsType": "time",
+                    "repsValue": 25,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60,
+                    "alternatives": [
+                      "V-Ups",
+                      "Dead Bugs"
+                    ]
+                  },
+                  {
+                    "$ref": "cooldown-passive-dead-hang"
+                  },
+                  {
+                    "category": "cooldown",
+                    "sets": 1,
+                    "exerciseName": "Butcher’s Block Stretch",
+                    "notes": "Cool-down. Targeting Lats/Triceps.",
+                    "repsType": "time",
+                    "repsValue": 60,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 0
+                  },
+                  {
+                    "$ref": "cooldown-cobra-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-wrist-extensor"
+                  }
+                ]
+              },
+              {
+                "$ref": "template-mobility-recovery",
+                "dayNumber": 2
+              },
+              {
+                "$ref": "template-lower-body",
+                "dayNumber": 3
+              },
+              {
+                "dayNumber": 5,
+                "name": "Pull Day B",
+                "type": "strength",
+                "estimatedDuration": 55,
+                "description": null,
+                "exercises": [
+                  {
+                    "$ref": "warmup-rower-zone1"
+                  },
+                  {
+                    "$ref": "warmup-rower-zone2"
+                  },
+                  {
+                    "$ref": "warmup-rower-sprints"
+                  },
+                  {
+                    "$ref": "warmup-band-pull-aparts"
+                  },
+                  {
+                    "$ref": "warmup-band-external-rotations"
+                  },
+                  {
+                    "$ref": "warmup-scapular-pullups"
+                  },
+                  {
+                    "$ref": "warmup-passive-bar-hang"
+                  },
+                  {
+                    "category": "main",
+                    "sets": 1,
+                    "exerciseName": "Weighted Pull-Ups",
+                    "notes": "Heavy. Primary Goal: Build elite pulling strength.",
+                    "loadMin": 5,
+                    "loadMax": 10,
+                    "loadUnit": "kg",
+                    "repsType": "reps",
+                    "repsValue": 4,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lat Pulldowns",
+                      "Ring Rows",
+                      "Assisted Pull-Ups"
+                    ],
+                    "progressionNotes": "DOUBLE PROGRESSION RULE: Earn weight increase only when hitting top rep range for ALL sets with perfect form. (e.g. if 3x5 is goal, must hit 5,5,5 to add 1kg).",
+                    "cues": [
+                      "Full ROM",
+                      "Chin over bar",
+                      "Controlled descent"
+                    ]
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Weighted Dips",
+                    "notes": "Dip Governor Rule: If shoulder pinch occurs, switch immediately.",
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "loadMin": 5,
+                    "loadMax": 10,
+                    "loadUnit": "kg",
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Dips",
+                      "Bench Dips",
+                      "Chest Press Machine"
+                    ],
+                    "progressionNotes": "Double Progression Rule applies.",
+                    "cues": [
+                      "Shoulders down",
+                      "Don't flair elbows"
+                    ]
+                  },
+                  {
+                    "category": "core",
+                    "sets": 3,
+                    "exerciseName": "Dead Bugs",
+                    "notes": "Core Recovery",
+                    "repsType": "reps",
+                    "repsValue": 12,
+                    "repsPerSide": true,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Bulgarian Split Squat",
+                    "notes": "Left side. EMOM. Unilateral Leg Work.",
+                    "loadMin": 10,
+                    "loadMax": 18,
+                    "loadUnit": "kg",
+                    "loadPerHand": true,
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "isEmom": true,
+                    "supersetGroup": 1,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lunges",
+                      "Step-Ups",
+                      "Split Squats"
+                    ],
+                    "cues": [
+                      "Vertical shin",
+                      "Drive through heel"
+                    ],
+                    "isUnilateral": true
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Bulgarian Split Squat",
+                    "notes": "Right side. EMOM. Unilateral Leg Work.",
+                    "loadMin": 10,
+                    "loadMax": 18,
+                    "loadUnit": "kg",
+                    "loadPerHand": true,
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "isEmom": true,
+                    "supersetGroup": 1,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lunges",
+                      "Step-Ups",
+                      "Split Squats"
+                    ],
+                    "cues": [
+                      "Vertical shin",
+                      "Drive through heel"
+                    ],
+                    "isUnilateral": true
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Weighted Hollow Rocks",
+                    "notes": "EMOM. Arms straight overhead. If lower back arches, drop weight immediately.",
+                    "loadMin": 3,
+                    "loadMax": 5,
+                    "loadUnit": "kg",
+                    "repsType": "reps",
+                    "repsValue": 15,
+                    "isEmom": true,
+                    "supersetGroup": 1,
+                    "restSeconds": 120,
+                    "progressionNotes": "Start 1.25/2.5kg. Move to 5kg only when holding shape perfectly for 45s."
+                  },
+                  {
+                    "$ref": "cooldown-banded-pec-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-lat-prayer"
+                  },
+                  {
+                    "$ref": "cooldown-standing-quad-stretch"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "weekNumber": 7,
+            "description": null,
+            "focus": null,
+            "volumeLevel": "high",
+            "intensityLevel": "high",
+            "days": [
+              {
+                "dayNumber": 1,
+                "name": "Pull Day A",
+                "type": "strength",
+                "estimatedDuration": 68,
+                "description": null,
+                "exercises": [
+                  {
+                    "$ref": "warmup-rower-zone1"
+                  },
+                  {
+                    "$ref": "warmup-rower-zone2"
+                  },
+                  {
+                    "$ref": "warmup-rower-sprints"
+                  },
+                  {
+                    "$ref": "warmup-band-pull-aparts"
+                  },
+                  {
+                    "$ref": "warmup-band-external-rotations"
+                  },
+                  {
+                    "$ref": "warmup-scapular-pullups"
+                  },
+                  {
+                    "$ref": "warmup-passive-bar-hang"
+                  },
+                  {
+                    "category": "main",
+                    "sets": 10,
+                    "exerciseName": "Pull-Up EMOM",
+                    "notes": "Intensity Peak. Perform reps at the start of every minute.",
+                    "repsType": "reps",
+                    "repsValue": 3,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "isEmom": true,
+                    "restSeconds": 120
+                  },
+                  {
+                    "category": "accessory",
+                    "sets": 3,
+                    "exerciseName": "Feet-Elevated Ring Rows",
+                    "notes": "Accessory. Tempo 2-1-1-0. Feet elevated for increased difficulty.",
+                    "repsType": "reps",
+                    "repsValue": 12,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60,
+                    "alternatives": [
+                      "Ring Rows",
+                      "Dumbbell Rows"
+                    ]
+                  },
+                  {
+                    "category": "accessory",
+                    "sets": 3,
+                    "exerciseName": "Parallette Push-Ups",
+                    "notes": "Accessory. Tempo 2-1-1-0. Increased ROM.",
+                    "repsType": "reps",
+                    "repsValue": 10,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60,
+                    "alternatives": [
+                      "Push-Ups",
+                      "Diamond Push-Ups"
+                    ]
+                  },
+                  {
+                    "category": "core",
+                    "sets": 3,
+                    "exerciseName": "Hollow Rocks",
+                    "notes": "Core. Ground-Based. Watch for elbow tightness.",
+                    "repsType": "time",
+                    "repsValue": 25,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60,
+                    "alternatives": [
+                      "V-Ups",
+                      "Dead Bugs"
+                    ]
+                  },
+                  {
+                    "$ref": "cooldown-passive-dead-hang"
+                  },
+                  {
+                    "category": "cooldown",
+                    "sets": 1,
+                    "exerciseName": "Butcher’s Block Stretch",
+                    "notes": "Cool-down. Targeting Lats/Triceps.",
+                    "repsType": "time",
+                    "repsValue": 60,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 0
+                  },
+                  {
+                    "$ref": "cooldown-cobra-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-wrist-extensor"
+                  }
+                ]
+              },
+              {
+                "$ref": "template-mobility-recovery",
+                "dayNumber": 2
+              },
+              {
+                "$ref": "template-lower-body",
+                "dayNumber": 3
+              },
+              {
+                "dayNumber": 5,
+                "name": "Pull Day B",
+                "type": "strength",
+                "estimatedDuration": 58,
+                "description": null,
+                "exercises": [
+                  {
+                    "$ref": "warmup-rower-zone1"
+                  },
+                  {
+                    "$ref": "warmup-rower-zone2"
+                  },
+                  {
+                    "$ref": "warmup-rower-sprints"
+                  },
+                  {
+                    "$ref": "warmup-band-pull-aparts"
+                  },
+                  {
+                    "$ref": "warmup-band-external-rotations"
+                  },
+                  {
+                    "$ref": "warmup-scapular-pullups"
+                  },
+                  {
+                    "$ref": "warmup-passive-bar-hang"
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Weighted Pull-Ups",
+                    "notes": "Heavy. Primary Goal: Build elite pulling strength.",
+                    "loadMin": 5,
+                    "loadMax": 10,
+                    "loadUnit": "kg",
+                    "repsType": "reps",
+                    "repsValue": 3,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lat Pulldowns",
+                      "Ring Rows",
+                      "Assisted Pull-Ups"
+                    ],
+                    "progressionNotes": "DOUBLE PROGRESSION RULE: Earn weight increase only when hitting top rep range for ALL sets with perfect form. (e.g. if 3x5 is goal, must hit 5,5,5 to add 1kg).",
+                    "cues": [
+                      "Full ROM",
+                      "Chin over bar",
+                      "Controlled descent"
+                    ]
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Weighted Dips",
+                    "notes": "Dip Governor Rule: If shoulder pinch occurs, switch immediately.",
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "loadMin": 5,
+                    "loadMax": 10,
+                    "loadUnit": "kg",
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Dips",
+                      "Bench Dips",
+                      "Chest Press Machine"
+                    ],
+                    "progressionNotes": "Double Progression Rule applies.",
+                    "cues": [
+                      "Shoulders down",
+                      "Don't flair elbows"
+                    ]
+                  },
+                  {
+                    "category": "core",
+                    "sets": 3,
+                    "exerciseName": "Weighted V-Ups",
+                    "notes": "Core Hard. Hard Core. Keep biceps by ears.",
+                    "loadMin": 3,
+                    "loadMax": 5,
+                    "loadUnit": "kg",
+                    "repsType": "reps",
+                    "repsValue": 12,
+                    "restSeconds": 60,
+                    "progressionNotes": "Start 1.25kg. Progress only with perfect form."
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Bulgarian Split Squat",
+                    "notes": "Left side. EMOM. Unilateral Leg Work.",
+                    "loadMin": 10,
+                    "loadMax": 18,
+                    "loadUnit": "kg",
+                    "loadPerHand": true,
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "isEmom": true,
+                    "supersetGroup": 1,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lunges",
+                      "Step-Ups",
+                      "Split Squats"
+                    ],
+                    "cues": [
+                      "Vertical shin",
+                      "Drive through heel"
+                    ],
+                    "isUnilateral": true
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Bulgarian Split Squat",
+                    "notes": "Right side. EMOM. Unilateral Leg Work.",
+                    "loadMin": 10,
+                    "loadMax": 18,
+                    "loadUnit": "kg",
+                    "loadPerHand": true,
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "isEmom": true,
+                    "supersetGroup": 1,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lunges",
+                      "Step-Ups",
+                      "Split Squats"
+                    ],
+                    "cues": [
+                      "Vertical shin",
+                      "Drive through heel"
+                    ],
+                    "isUnilateral": true
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Weighted Hollow Rocks",
+                    "notes": "EMOM. Arms straight overhead. If lower back arches, drop weight immediately.",
+                    "loadMin": 3,
+                    "loadMax": 5,
+                    "loadUnit": "kg",
+                    "repsType": "reps",
+                    "repsValue": 15,
+                    "isEmom": true,
+                    "supersetGroup": 1,
+                    "restSeconds": 120,
+                    "progressionNotes": "Start 1.25/2.5kg. Move to 5kg only when holding shape perfectly for 45s."
+                  },
+                  {
+                    "$ref": "cooldown-banded-pec-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-lat-prayer"
+                  },
+                  {
+                    "$ref": "cooldown-standing-quad-stretch"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "weekNumber": 8,
+            "description": null,
+            "focus": null,
+            "volumeLevel": "low",
+            "intensityLevel": "low",
+            "days": [
+              {
+                "dayNumber": 1,
+                "name": "Pull Day A",
+                "type": "strength",
+                "estimatedDuration": 62,
+                "description": null,
+                "exercises": [
+                  {
+                    "$ref": "warmup-rower-zone1"
+                  },
+                  {
+                    "$ref": "warmup-rower-zone2"
+                  },
+                  {
+                    "$ref": "warmup-rower-sprints"
+                  },
+                  {
+                    "$ref": "warmup-band-pull-aparts"
+                  },
+                  {
+                    "$ref": "warmup-band-external-rotations"
+                  },
+                  {
+                    "$ref": "warmup-scapular-pullups"
+                  },
+                  {
+                    "$ref": "warmup-passive-bar-hang"
+                  },
+                  {
+                    "category": "main",
+                    "sets": 6,
+                    "exerciseName": "Pull-Up EMOM",
+                    "notes": "Deload Volume. Perform reps at the start of every minute.",
+                    "repsType": "reps",
+                    "repsValue": 3,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "isEmom": true,
+                    "restSeconds": 120
+                  },
+                  {
+                    "category": "accessory",
+                    "sets": 2,
+                    "exerciseName": "Feet-Elevated Ring Rows",
+                    "notes": "Deload. Accessory. Tempo 2-1-1-0. Feet elevated for increased difficulty.",
+                    "repsType": "reps",
+                    "repsValue": 12,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60,
+                    "alternatives": [
+                      "Ring Rows",
+                      "Dumbbell Rows"
+                    ]
+                  },
+                  {
+                    "category": "accessory",
+                    "sets": 2,
+                    "exerciseName": "Parallette Push-Ups",
+                    "notes": "Deload. Accessory. Tempo 2-1-1-0. Increased ROM.",
+                    "repsType": "reps",
+                    "repsValue": 10,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60,
+                    "alternatives": [
+                      "Push-Ups",
+                      "Diamond Push-Ups"
+                    ]
+                  },
+                  {
+                    "category": "core",
+                    "sets": 2,
+                    "exerciseName": "Hollow Rocks",
+                    "notes": "Deload. Core. Ground-Based. Watch for elbow tightness.",
+                    "repsType": "time",
+                    "repsValue": 25,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60,
+                    "alternatives": [
+                      "V-Ups",
+                      "Dead Bugs"
+                    ]
+                  },
+                  {
+                    "$ref": "cooldown-passive-dead-hang"
+                  },
+                  {
+                    "category": "cooldown",
+                    "sets": 1,
+                    "exerciseName": "Butcher’s Block Stretch",
+                    "notes": "Cool-down. Targeting Lats/Triceps.",
+                    "repsType": "time",
+                    "repsValue": 60,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 0
+                  },
+                  {
+                    "$ref": "cooldown-cobra-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-wrist-extensor"
+                  }
+                ]
+              },
+              {
+                "$ref": "template-mobility-recovery",
+                "dayNumber": 2
+              },
+              {
+                "dayNumber": 3,
+                "name": "Lower Body",
+                "type": "strength",
+                "estimatedDuration": 23,
+                "description": null,
+                "exercises": [
+                  {
+                    "category": "main",
+                    "sets": 2,
+                    "exerciseName": "RDL",
+                    "notes": "Deload. Posterior chain focus.",
+                    "loadMin": 60,
+                    "loadMax": 80,
+                    "loadUnit": "kg",
+                    "repsType": "reps",
+                    "repsValue": 10,
+                    "restSeconds": 120
+                  },
+                  {
+                    "category": "main",
+                    "sets": 2,
+                    "exerciseName": "Rower Leg Curls (2-Leg)",
+                    "notes": "Deload. Protocol: Min 1-2: Easy (Zone 1). Min 3-4: Moderate (Zone 2). Min 5: 3x10s Sprints.",
+                    "repsType": "reps",
+                    "repsValue": 10,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 120
+                  },
+                  {
+                    "$ref": "main-goblet-squats",
+                    "sets": 2,
+                    "notes": "Deload. Reinforce healthy squat patterns. Ankle mobility focus."
+                  },
+                  {
+                    "category": "main",
+                    "sets": 2,
+                    "exerciseName": "Back Extensions",
+                    "notes": "Deload. Tempo 2-1-1-0.",
+                    "repsType": "reps",
+                    "repsValue": 12,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 120
+                  },
+                  {
+                    "$ref": "cooldown-couch-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-jefferson-curl"
+                  },
+                  {
+                    "$ref": "cooldown-90-90-hip-rotations"
+                  }
+                ]
+              },
+              {
+                "$ref": "template-pull-day-b",
+                "dayNumber": 5
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "phaseNumber": 3,
+        "name": "Intermediate Phase",
+        "description": "Progressive overload with skill integration",
+        "startWeek": 9,
+        "endWeek": 12,
+        "focus": "skill",
+        "weeks": [
+          {
+            "weekNumber": 9,
+            "description": null,
+            "focus": null,
+            "volumeLevel": "moderate",
+            "intensityLevel": "moderate",
+            "days": [
+              {
+                "dayNumber": 1,
+                "name": "Pull Day A",
+                "type": "strength",
+                "estimatedDuration": 59,
+                "description": null,
+                "exercises": [
+                  {
+                    "$ref": "warmup-rower-zone1"
+                  },
+                  {
+                    "$ref": "warmup-rower-zone2"
+                  },
+                  {
+                    "$ref": "warmup-rower-sprints"
+                  },
+                  {
+                    "$ref": "warmup-band-pull-aparts"
+                  },
+                  {
+                    "$ref": "warmup-band-external-rotations"
+                  },
+                  {
+                    "$ref": "warmup-scapular-pullups"
+                  },
+                  {
+                    "$ref": "warmup-passive-bar-hang"
+                  },
+                  {
+                    "category": "main",
+                    "sets": 4,
+                    "exerciseName": "Cluster Pull-Ups (Neutral)",
+                    "notes": "Unilateral Prep. Cluster sets for unilateral stability.",
+                    "repsType": "ladder",
+                    "repsValue": [
+                      3,
+                      3,
+                      3
+                    ],
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lat Pulldowns",
+                      "Ring Rows",
+                      "Assisted Pull-Ups"
+                    ]
+                  },
+                  {
+                    "category": "accessory",
+                    "sets": 3,
+                    "exerciseName": "Feet-Elevated Ring Rows",
+                    "notes": "Accessory. Tempo 2-1-1-0. Neutral grip block.",
+                    "repsType": "reps",
+                    "repsValue": 12,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60
+                  },
+                  {
+                    "category": "accessory",
+                    "sets": 3,
+                    "exerciseName": "Parallette Push-Ups",
+                    "notes": "Accessory. Tempo 2-1-1-0.",
+                    "repsType": "reps",
+                    "repsValue": 10,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60
+                  },
+                  {
+                    "$ref": "cooldown-passive-dead-hang"
+                  },
+                  {
+                    "category": "cooldown",
+                    "sets": 1,
+                    "exerciseName": "Butcher’s Block Stretch",
+                    "notes": "Cool-down. Targeting Lats/Triceps.",
+                    "repsType": "time",
+                    "repsValue": 60,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 0
+                  },
+                  {
+                    "$ref": "cooldown-cobra-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-wrist-extensor"
+                  }
+                ]
+              },
+              {
+                "$ref": "template-mobility-recovery",
+                "dayNumber": 2
+              },
+              {
+                "$ref": "template-lower-body-1",
+                "dayNumber": 3
+              },
+              {
+                "dayNumber": 5,
+                "name": "Pull Day B",
+                "type": "strength",
+                "estimatedDuration": 61,
+                "description": null,
+                "exercises": [
+                  {
+                    "$ref": "warmup-rower-zone1"
+                  },
+                  {
+                    "$ref": "warmup-rower-zone2"
+                  },
+                  {
+                    "$ref": "warmup-rower-sprints"
+                  },
+                  {
+                    "$ref": "warmup-band-pull-aparts"
+                  },
+                  {
+                    "$ref": "warmup-band-external-rotations"
+                  },
+                  {
+                    "$ref": "warmup-scapular-pullups"
+                  },
+                  {
+                    "$ref": "warmup-passive-bar-hang"
+                  },
+                  {
+                    "category": "main",
+                    "sets": 2,
+                    "exerciseName": "Neutral Grip Weighted Pull-Ups",
+                    "notes": "Safe Load. Primary Goal: Build elite pulling strength.",
+                    "loadMin": 5,
+                    "loadMax": 10,
+                    "loadUnit": "kg",
+                    "repsType": "reps",
+                    "repsValue": 3,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lat Pulldowns",
+                      "Ring Rows",
+                      "Assisted Pull-Ups"
+                    ],
+                    "progressionNotes": "DOUBLE PROGRESSION RULE: Earn weight increase only when hitting top rep range for ALL sets with perfect form. (e.g. if 3x5 is goal, must hit 5,5,5 to add 1kg).",
+                    "cues": [
+                      "Full ROM",
+                      "Chin over bar",
+                      "Controlled descent"
+                    ]
+                  },
+                  {
+                    "category": "accessory",
+                    "sets": 3,
+                    "exerciseName": "PPPU",
+                    "notes": "Accessory. Pseudo Planche Push Up. Maintain scapular protraction throughout.",
+                    "repsType": "reps",
+                    "repsMin": 5,
+                    "repsMax": 8,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60,
+                    "cues": [
+                      "Lean forward",
+                      "Glutes squeezed"
+                    ]
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Bulgarian Split Squat",
+                    "notes": "Left side. EMOM. Unilateral Leg Work. Squat pattern for balanced lower body development.",
+                    "loadMin": 10,
+                    "loadMax": 18,
+                    "loadUnit": "kg",
+                    "loadPerHand": true,
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "isEmom": true,
+                    "supersetGroup": 1,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lunges",
+                      "Step-Ups",
+                      "Split Squats"
+                    ],
+                    "cues": [
+                      "Vertical shin",
+                      "Drive through heel"
+                    ],
+                    "isUnilateral": true
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Bulgarian Split Squat",
+                    "notes": "Right side. EMOM. Unilateral Leg Work. Squat pattern for balanced lower body development.",
+                    "loadMin": 10,
+                    "loadMax": 18,
+                    "loadUnit": "kg",
+                    "loadPerHand": true,
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "isEmom": true,
+                    "supersetGroup": 1,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lunges",
+                      "Step-Ups",
+                      "Split Squats"
+                    ],
+                    "cues": [
+                      "Vertical shin",
+                      "Drive through heel"
+                    ],
+                    "isUnilateral": true
+                  },
+                  {
+                    "category": "core",
+                    "sets": 3,
+                    "exerciseName": "Weighted Hollow Rocks",
+                    "notes": "EMOM. Arms straight overhead. If lower back arches, drop weight immediately.",
+                    "loadMin": 3,
+                    "loadMax": 5,
+                    "loadUnit": "kg",
+                    "repsType": "reps",
+                    "repsValue": 15,
+                    "isEmom": true,
+                    "supersetGroup": 1,
+                    "restSeconds": 120,
+                    "progressionNotes": "Start 1.25/2.5kg. Move to 5kg only when holding shape perfectly for 45s."
+                  },
+                  {
+                    "$ref": "cooldown-banded-pec-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-lat-prayer"
+                  },
+                  {
+                    "$ref": "cooldown-standing-quad-stretch"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "weekNumber": 10,
+            "description": null,
+            "focus": null,
+            "volumeLevel": "high",
+            "intensityLevel": "moderate",
+            "days": [
+              {
+                "dayNumber": 1,
+                "name": "Pull Day A",
+                "type": "strength",
+                "estimatedDuration": 59,
+                "description": null,
+                "exercises": [
+                  {
+                    "$ref": "warmup-rower-zone1"
+                  },
+                  {
+                    "$ref": "warmup-rower-zone2"
+                  },
+                  {
+                    "$ref": "warmup-rower-sprints"
+                  },
+                  {
+                    "$ref": "warmup-band-pull-aparts"
+                  },
+                  {
+                    "$ref": "warmup-band-external-rotations"
+                  },
+                  {
+                    "$ref": "warmup-scapular-pullups"
+                  },
+                  {
+                    "$ref": "warmup-passive-bar-hang"
+                  },
+                  {
+                    "category": "main",
+                    "sets": 4,
+                    "exerciseName": "Cluster Pull-Ups (Neutral)",
+                    "notes": "Volume Increase. Cluster sets for unilateral stability.",
+                    "repsType": "ladder",
+                    "repsValue": [
+                      4,
+                      3,
+                      3
+                    ],
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lat Pulldowns",
+                      "Ring Rows",
+                      "Assisted Pull-Ups"
+                    ]
+                  },
+                  {
+                    "category": "accessory",
+                    "sets": 3,
+                    "exerciseName": "Feet-Elevated Ring Rows",
+                    "notes": "Accessory. Tempo 2-1-1-0. Neutral grip block.",
+                    "repsType": "reps",
+                    "repsValue": 12,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60
+                  },
+                  {
+                    "category": "accessory",
+                    "sets": 3,
+                    "exerciseName": "Parallette Push-Ups",
+                    "notes": "Accessory. Tempo 2-1-1-0.",
+                    "repsType": "reps",
+                    "repsValue": 10,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60
+                  },
+                  {
+                    "$ref": "cooldown-passive-dead-hang"
+                  },
+                  {
+                    "category": "cooldown",
+                    "sets": 1,
+                    "exerciseName": "Butcher’s Block Stretch",
+                    "notes": "Cool-down. Targeting Lats/Triceps.",
+                    "repsType": "time",
+                    "repsValue": 60,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 0
+                  },
+                  {
+                    "$ref": "cooldown-cobra-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-wrist-extensor"
+                  }
+                ]
+              },
+              {
+                "$ref": "template-mobility-recovery",
+                "dayNumber": 2
+              },
+              {
+                "$ref": "template-lower-body-1",
+                "dayNumber": 3
+              },
+              {
+                "dayNumber": 5,
+                "name": "Pull Day B",
+                "type": "strength",
+                "estimatedDuration": 61,
+                "description": null,
+                "exercises": [
+                  {
+                    "$ref": "warmup-rower-zone1"
+                  },
+                  {
+                    "$ref": "warmup-rower-zone2"
+                  },
+                  {
+                    "$ref": "warmup-rower-sprints"
+                  },
+                  {
+                    "$ref": "warmup-band-pull-aparts"
+                  },
+                  {
+                    "$ref": "warmup-band-external-rotations"
+                  },
+                  {
+                    "$ref": "warmup-scapular-pullups"
+                  },
+                  {
+                    "$ref": "warmup-passive-bar-hang"
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Ring Support Holds",
+                    "notes": "Isometric",
+                    "repsType": "time",
+                    "repsValue": 30,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 120
+                  },
+                  {
+                    "category": "accessory",
+                    "sets": 2,
+                    "exerciseName": "Chest Supported Row",
+                    "notes": "Accessory",
+                    "loadMin": 10,
+                    "loadMax": 15,
+                    "loadUnit": "kg",
+                    "loadPerHand": true,
+                    "repsType": "reps",
+                    "repsValue": 12,
+                    "restSeconds": 60
+                  },
+                  {
+                    "category": "core",
+                    "sets": 3,
+                    "exerciseName": "Dead Bugs",
+                    "notes": "Core Recovery",
+                    "repsType": "reps",
+                    "repsValue": 12,
+                    "repsPerSide": true,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Bulgarian Split Squat",
+                    "notes": "Left side. EMOM. Unilateral Leg Work. Squat pattern for balanced lower body development.",
+                    "loadMin": 10,
+                    "loadMax": 18,
+                    "loadUnit": "kg",
+                    "loadPerHand": true,
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "isEmom": true,
+                    "supersetGroup": 1,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lunges",
+                      "Step-Ups",
+                      "Split Squats"
+                    ],
+                    "cues": [
+                      "Vertical shin",
+                      "Drive through heel"
+                    ],
+                    "isUnilateral": true
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Bulgarian Split Squat",
+                    "notes": "Right side. EMOM. Unilateral Leg Work. Squat pattern for balanced lower body development.",
+                    "loadMin": 10,
+                    "loadMax": 18,
+                    "loadUnit": "kg",
+                    "loadPerHand": true,
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "isEmom": true,
+                    "supersetGroup": 1,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lunges",
+                      "Step-Ups",
+                      "Split Squats"
+                    ],
+                    "cues": [
+                      "Vertical shin",
+                      "Drive through heel"
+                    ],
+                    "isUnilateral": true
+                  },
+                  {
+                    "category": "core",
+                    "sets": 3,
+                    "exerciseName": "Weighted Hollow Rocks",
+                    "notes": "EMOM. Arms straight overhead. If lower back arches, drop weight immediately.",
+                    "loadMin": 3,
+                    "loadMax": 5,
+                    "loadUnit": "kg",
+                    "repsType": "reps",
+                    "repsValue": 15,
+                    "isEmom": true,
+                    "supersetGroup": 1,
+                    "restSeconds": 120,
+                    "progressionNotes": "Start 1.25/2.5kg. Move to 5kg only when holding shape perfectly for 45s."
+                  },
+                  {
+                    "$ref": "cooldown-banded-pec-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-lat-prayer"
+                  },
+                  {
+                    "$ref": "cooldown-standing-quad-stretch"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "weekNumber": 11,
+            "description": null,
+            "focus": null,
+            "volumeLevel": "high",
+            "intensityLevel": "high",
+            "days": [
+              {
+                "dayNumber": 1,
+                "name": "Pull Day A",
+                "type": "strength",
+                "estimatedDuration": 60,
+                "description": null,
+                "exercises": [
+                  {
+                    "$ref": "warmup-rower-zone1"
+                  },
+                  {
+                    "$ref": "warmup-rower-zone2"
+                  },
+                  {
+                    "$ref": "warmup-rower-sprints"
+                  },
+                  {
+                    "$ref": "warmup-band-pull-aparts"
+                  },
+                  {
+                    "$ref": "warmup-band-external-rotations"
+                  },
+                  {
+                    "$ref": "warmup-scapular-pullups"
+                  },
+                  {
+                    "$ref": "warmup-passive-bar-hang"
+                  },
+                  {
+                    "category": "main",
+                    "sets": 5,
+                    "exerciseName": "Cluster Pull-Ups (Neutral)",
+                    "notes": "Volume Peak. Cluster sets for unilateral stability.",
+                    "repsType": "ladder",
+                    "repsValue": [
+                      3,
+                      3,
+                      3
+                    ],
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lat Pulldowns",
+                      "Ring Rows",
+                      "Assisted Pull-Ups"
+                    ]
+                  },
+                  {
+                    "category": "accessory",
+                    "sets": 3,
+                    "exerciseName": "Feet-Elevated Ring Rows",
+                    "notes": "Accessory. Tempo 2-1-1-0. Neutral grip block.",
+                    "repsType": "reps",
+                    "repsValue": 12,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60
+                  },
+                  {
+                    "category": "accessory",
+                    "sets": 3,
+                    "exerciseName": "Parallette Push-Ups",
+                    "notes": "Accessory. Tempo 2-1-1-0.",
+                    "repsType": "reps",
+                    "repsValue": 10,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60
+                  },
+                  {
+                    "$ref": "cooldown-passive-dead-hang"
+                  },
+                  {
+                    "category": "cooldown",
+                    "sets": 1,
+                    "exerciseName": "Butcher’s Block Stretch",
+                    "notes": "Cool-down. Targeting Lats/Triceps.",
+                    "repsType": "time",
+                    "repsValue": 60,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 0
+                  },
+                  {
+                    "$ref": "cooldown-cobra-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-wrist-extensor"
+                  }
+                ]
+              },
+              {
+                "$ref": "template-mobility-recovery",
+                "dayNumber": 2
+              },
+              {
+                "$ref": "template-lower-body-1",
+                "dayNumber": 3
+              },
+              {
+                "dayNumber": 5,
+                "name": "Pull Day B",
+                "type": "strength",
+                "estimatedDuration": 57,
+                "description": null,
+                "exercises": [
+                  {
+                    "$ref": "warmup-rower-zone1"
+                  },
+                  {
+                    "$ref": "warmup-rower-zone2"
+                  },
+                  {
+                    "$ref": "warmup-rower-sprints"
+                  },
+                  {
+                    "$ref": "warmup-band-pull-aparts"
+                  },
+                  {
+                    "$ref": "warmup-band-external-rotations"
+                  },
+                  {
+                    "$ref": "warmup-scapular-pullups"
+                  },
+                  {
+                    "$ref": "warmup-passive-bar-hang"
+                  },
+                  {
+                    "category": "main",
+                    "sets": 2,
+                    "exerciseName": "Neutral Grip Weighted Pull-Ups",
+                    "notes": "Heavy. Primary Goal: Build elite pulling strength.",
+                    "loadMin": 5,
+                    "loadMax": 10,
+                    "loadUnit": "kg",
+                    "repsType": "reps",
+                    "repsValue": 4,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lat Pulldowns",
+                      "Ring Rows",
+                      "Assisted Pull-Ups"
+                    ],
+                    "progressionNotes": "DOUBLE PROGRESSION RULE: Earn weight increase only when hitting top rep range for ALL sets with perfect form. (e.g. if 3x5 is goal, must hit 5,5,5 to add 1kg).",
+                    "cues": [
+                      "Full ROM",
+                      "Chin over bar",
+                      "Controlled descent"
+                    ]
+                  },
+                  {
+                    "category": "core",
+                    "sets": 3,
+                    "exerciseName": "Weighted V-Ups",
+                    "notes": "Core Hard. Hard Core. Keep biceps by ears.",
+                    "loadMin": 3,
+                    "loadMax": 5,
+                    "loadUnit": "kg",
+                    "repsType": "reps",
+                    "repsValue": 12,
+                    "restSeconds": 60,
+                    "progressionNotes": "Start 1.25kg. Progress only with perfect form."
+                  },
+                  {
+                    "category": "skill",
+                    "sets": 3,
+                    "exerciseName": "PPPU (Pseudo Planche Push-Ups)",
+                    "notes": "Skill. Lean forward, hands at hip level.",
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 90,
+                    "cues": [
+                      "Protract scapula",
+                      "Lean forward"
+                    ]
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Bulgarian Split Squat",
+                    "notes": "Left side. EMOM. Unilateral Leg Work. Squat pattern for balanced lower body development.",
+                    "loadMin": 10,
+                    "loadMax": 18,
+                    "loadUnit": "kg",
+                    "loadPerHand": true,
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "isEmom": true,
+                    "supersetGroup": 1,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lunges",
+                      "Step-Ups",
+                      "Split Squats"
+                    ],
+                    "cues": [
+                      "Vertical shin",
+                      "Drive through heel"
+                    ],
+                    "isUnilateral": true
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Bulgarian Split Squat",
+                    "notes": "Right side. EMOM. Unilateral Leg Work. Squat pattern for balanced lower body development.",
+                    "loadMin": 10,
+                    "loadMax": 18,
+                    "loadUnit": "kg",
+                    "loadPerHand": true,
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "isEmom": true,
+                    "supersetGroup": 1,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lunges",
+                      "Step-Ups",
+                      "Split Squats"
+                    ],
+                    "cues": [
+                      "Vertical shin",
+                      "Drive through heel"
+                    ],
+                    "isUnilateral": true
+                  },
+                  {
+                    "category": "core",
+                    "sets": 3,
+                    "exerciseName": "Weighted Hollow Rocks",
+                    "notes": "EMOM. Arms straight overhead. If lower back arches, drop weight immediately.",
+                    "loadMin": 3,
+                    "loadMax": 5,
+                    "loadUnit": "kg",
+                    "repsType": "reps",
+                    "repsValue": 15,
+                    "isEmom": true,
+                    "supersetGroup": 1,
+                    "restSeconds": 120,
+                    "progressionNotes": "Start 1.25/2.5kg. Move to 5kg only when holding shape perfectly for 45s."
+                  },
+                  {
+                    "$ref": "cooldown-banded-pec-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-lat-prayer"
+                  },
+                  {
+                    "$ref": "cooldown-standing-quad-stretch"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "weekNumber": 12,
+            "description": "Connective-tissue deload — explicit restrictions: NO Dead Hangs, NO Long Hollow Holds, NO Weighted Core",
+            "focus": "deload",
+            "volumeLevel": "low",
+            "intensityLevel": "low",
+            "days": [
+              {
+                "dayNumber": 1,
+                "name": "Pull Day A (Connective-Tissue Deload)",
+                "type": "recovery",
+                "estimatedDuration": 57,
+                "description": null,
+                "exercises": [
+                  {
+                    "$ref": "warmup-rower-zone1"
+                  },
+                  {
+                    "$ref": "warmup-rower-zone2"
+                  },
+                  {
+                    "$ref": "warmup-rower-sprints"
+                  },
+                  {
+                    "$ref": "warmup-band-pull-aparts"
+                  },
+                  {
+                    "$ref": "warmup-band-external-rotations"
+                  },
+                  {
+                    "$ref": "warmup-scapular-pullups"
+                  },
+                  {
+                    "$ref": "warmup-passive-bar-hang"
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Clusters",
+                    "notes": "Deload. 3x(3-3-3). Do not exceed low tension rules. NO Dead Hangs, NO Long Hollow Holds, NO Weighted Core.",
+                    "repsType": "ladder",
+                    "repsValue": [
+                      3,
+                      3,
+                      3
+                    ],
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lat Pulldowns",
+                      "Ring Rows",
+                      "Assisted Pull-Ups"
+                    ]
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Straight-Arm Tuck Holds",
+                    "notes": "Deload. Max 3×6s per program restrictions; NO dead hangs.",
+                    "repsType": "time",
+                    "repsValue": 6,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60
+                  },
+                  {
+                    "category": "accessory",
+                    "sets": 2,
+                    "exerciseName": "Feet-Elevated Ring Rows",
+                    "notes": "Deload. Accessory. Tempo 2-1-1-0. Neutral grip block.",
+                    "repsType": "reps",
+                    "repsValue": 12,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60
+                  },
+                  {
+                    "category": "accessory",
+                    "sets": 2,
+                    "exerciseName": "Parallette Push-Ups",
+                    "notes": "Deload. Accessory. Tempo 2-1-1-0.",
+                    "repsType": "reps",
+                    "repsValue": 10,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60
+                  },
+                  {
+                    "$ref": "cooldown-butchers-block",
+                    "notes": "Cool-down. Spinal decompression."
+                  },
+                  {
+                    "category": "cooldown",
+                    "sets": 1,
+                    "exerciseName": "Butcher’s Block Stretch",
+                    "notes": "Cool-down. Targeting Lats/Triceps.",
+                    "repsType": "time",
+                    "repsValue": 60,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 0
+                  },
+                  {
+                    "$ref": "cooldown-cobra-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-wrist-extensor"
+                  }
+                ]
+              },
+              {
+                "$ref": "template-mobility-recovery",
+                "dayNumber": 2
+              },
+              {
+                "dayNumber": 3,
+                "name": "Lower Body",
+                "type": "strength",
+                "estimatedDuration": 20,
+                "description": null,
+                "exercises": [
+                  {
+                    "category": "main",
+                    "sets": 2,
+                    "exerciseName": "Single Leg RDL",
+                    "notes": "Deload. Posterior chain focus.",
+                    "loadMin": 8,
+                    "loadMax": 12,
+                    "loadUnit": "kg",
+                    "loadPerHand": true,
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "repsPerSide": true,
+                    "restSeconds": 120
+                  },
+                  {
+                    "$ref": "main-goblet-squats",
+                    "sets": 2,
+                    "notes": "Deload. Reinforce healthy squat patterns. Ankle mobility focus."
+                  },
+                  {
+                    "$ref": "accessory-face-pulls",
+                    "category": "main",
+                    "sets": 2,
+                    "restSeconds": 120,
+                    "notes": "Deload. Tempo 2-1-1-0. Upper back health."
+                  },
+                  {
+                    "$ref": "cooldown-couch-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-jefferson-curl"
+                  },
+                  {
+                    "$ref": "cooldown-90-90-hip-rotations"
+                  }
+                ]
+              },
+              {
+                "dayNumber": 5,
+                "name": "Pull Day B",
+                "type": "strength",
+                "estimatedDuration": 52,
+                "description": null,
+                "exercises": [
+                  {
+                    "$ref": "warmup-rower-zone1"
+                  },
+                  {
+                    "$ref": "warmup-rower-zone2"
+                  },
+                  {
+                    "$ref": "warmup-rower-sprints"
+                  },
+                  {
+                    "$ref": "warmup-band-pull-aparts"
+                  },
+                  {
+                    "$ref": "warmup-band-external-rotations"
+                  },
+                  {
+                    "$ref": "warmup-scapular-pullups"
+                  },
+                  {
+                    "$ref": "warmup-passive-bar-hang"
+                  },
+                  {
+                    "category": "main",
+                    "sets": 2,
+                    "exerciseName": "Neutral Grip Pull-ups (Light)",
+                    "notes": "Deload. Unweighted or very light per doc. NO Dead Hangs, NO Long Hollow Holds, NO Weighted Core.",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "repsType": "reps",
+                    "repsValue": 3,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lat Pulldowns",
+                      "Ring Rows",
+                      "Assisted Pull-Ups"
+                    ],
+                    "cues": [
+                      "Full ROM",
+                      "Chin over bar",
+                      "Controlled descent"
+                    ]
+                  },
+                  {
+                    "category": "skill",
+                    "sets": 2,
+                    "exerciseName": "PPPU (Pseudo Planche Push-Ups)",
+                    "notes": "Deload. Skill. Lean forward, hands at hip level.",
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 90,
+                    "cues": [
+                      "Protract scapula",
+                      "Lean forward"
+                    ]
+                  },
+                  {
+                    "category": "core",
+                    "sets": 2,
+                    "exerciseName": "Hollow Hold",
+                    "notes": "Deload. Core. Ground-Based isometric.",
+                    "repsType": "time",
+                    "repsValue": 30,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60
+                  },
+                  {
+                    "$ref": "cooldown-banded-pec-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-lat-prayer"
+                  },
+                  {
+                    "$ref": "cooldown-standing-quad-stretch"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "phaseNumber": 4,
+        "name": "Advanced Phase",
+        "description": "Peak strength and skill development",
+        "startWeek": 13,
+        "endWeek": 16,
+        "focus": "intensity",
+        "weeks": [
+          {
+            "weekNumber": 13,
+            "description": null,
+            "focus": null,
+            "volumeLevel": "moderate",
+            "intensityLevel": "moderate",
+            "days": [
+              {
+                "dayNumber": 1,
+                "name": "Pull Day A",
+                "type": "strength",
+                "estimatedDuration": 57,
+                "description": null,
+                "exercises": [
+                  {
+                    "$ref": "warmup-rower-zone1"
+                  },
+                  {
+                    "$ref": "warmup-rower-zone2"
+                  },
+                  {
+                    "$ref": "warmup-rower-sprints"
+                  },
+                  {
+                    "$ref": "warmup-band-pull-aparts"
+                  },
+                  {
+                    "$ref": "warmup-band-external-rotations"
+                  },
+                  {
+                    "$ref": "warmup-scapular-pullups"
+                  },
+                  {
+                    "$ref": "warmup-passive-bar-hang"
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Pull-Ups",
+                    "notes": "Accumulation",
+                    "repsType": "amrap",
+                    "repsValue": null,
+                    "repsModifier": 2,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lat Pulldowns",
+                      "Ring Rows",
+                      "Assisted Pull-Ups"
+                    ]
+                  },
+                  {
+                    "category": "accessory",
+                    "sets": 3,
+                    "exerciseName": "Feet-on-Floor Rows",
+                    "notes": "Accessory. Tempo 3-1-1-0. Maintain pulling volume.",
+                    "repsType": "reps",
+                    "repsValue": 10,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60,
+                    "alternatives": [
+                      "Ring Rows",
+                      "Dumbbell Rows"
+                    ]
+                  },
+                  {
+                    "$ref": "cooldown-passive-dead-hang"
+                  },
+                  {
+                    "category": "cooldown",
+                    "sets": 1,
+                    "exerciseName": "Butcher’s Block Stretch",
+                    "notes": "Cool-down. Targeting Lats/Triceps.",
+                    "repsType": "time",
+                    "repsValue": 60,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 0
+                  },
+                  {
+                    "$ref": "cooldown-cobra-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-wrist-extensor"
+                  }
+                ]
+              },
+              {
+                "$ref": "template-mobility-recovery",
+                "dayNumber": 2
+              },
+              {
+                "$ref": "template-lower-body-2",
+                "dayNumber": 3
+              },
+              {
+                "dayNumber": 5,
+                "name": "Pull Day B",
+                "type": "strength",
+                "estimatedDuration": 66,
+                "description": null,
+                "exercises": [
+                  {
+                    "$ref": "warmup-rower-zone1"
+                  },
+                  {
+                    "$ref": "warmup-rower-zone2"
+                  },
+                  {
+                    "$ref": "warmup-rower-sprints"
+                  },
+                  {
+                    "$ref": "warmup-band-pull-aparts"
+                  },
+                  {
+                    "$ref": "warmup-band-external-rotations"
+                  },
+                  {
+                    "$ref": "warmup-scapular-pullups"
+                  },
+                  {
+                    "$ref": "warmup-passive-bar-hang"
+                  },
+                  {
+                    "category": "main",
+                    "sets": 2,
+                    "exerciseName": "Weighted Pull-Ups",
+                    "notes": "Primary Goal: Build elite pulling strength.",
+                    "loadMin": 14,
+                    "loadMax": 14,
+                    "loadUnit": "kg",
+                    "repsType": "reps",
+                    "repsValue": 4,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lat Pulldowns",
+                      "Ring Rows",
+                      "Assisted Pull-Ups"
+                    ],
+                    "progressionNotes": "DOUBLE PROGRESSION RULE: Earn weight increase only when hitting top rep range for ALL sets with perfect form. (e.g. if 3x5 is goal, must hit 5,5,5 to add 1kg).",
+                    "cues": [
+                      "Full ROM",
+                      "Chin over bar",
+                      "Controlled descent"
+                    ]
+                  },
+                  {
+                    "category": "accessory",
+                    "sets": 4,
+                    "exerciseName": "Weighted Dips",
+                    "notes": "Accessory. Dip Governor Rule: If shoulder pinch occurs, switch immediately.",
+                    "loadMin": 5,
+                    "loadMax": 10,
+                    "loadUnit": "kg",
+                    "repsType": "reps",
+                    "repsValue": 5,
+                    "restSeconds": 60,
+                    "alternatives": [
+                      "Push-Ups",
+                      "Bench Dips",
+                      "Chest Press Machine"
+                    ],
+                    "progressionNotes": "Double Progression Rule: Hit top reps to add weight."
+                  },
+                  {
+                    "category": "main",
+                    "sets": 2,
+                    "exerciseName": "Chest Supported Row",
+                    "notes": null,
+                    "loadMin": 10,
+                    "loadMax": 15,
+                    "loadUnit": "kg",
+                    "loadPerHand": true,
+                    "repsType": "reps",
+                    "repsValue": 12,
+                    "tempoEccentric": 2,
+                    "tempoPauseBottom": 1,
+                    "tempoConcentric": 1,
+                    "tempoPauseTop": 0,
+                    "restSeconds": 120
+                  },
+                  {
+                    "category": "core",
+                    "sets": 3,
+                    "exerciseName": "Side Planks",
+                    "notes": "Core Recovery",
+                    "repsType": "time",
+                    "repsValue": 45,
+                    "repsUnit": "seconds",
+                    "repsPerSide": true,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Bulgarian Split Squat",
+                    "notes": "Left side. EMOM. Unilateral Leg Work. Squat pattern for balanced lower body development.",
+                    "loadMin": 10,
+                    "loadMax": 18,
+                    "loadUnit": "kg",
+                    "loadPerHand": true,
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "isEmom": true,
+                    "supersetGroup": 1,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lunges",
+                      "Step-Ups",
+                      "Split Squats"
+                    ],
+                    "cues": [
+                      "Vertical shin",
+                      "Drive through heel"
+                    ],
+                    "isUnilateral": true
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Bulgarian Split Squat",
+                    "notes": "Right side. EMOM. Unilateral Leg Work. Squat pattern for balanced lower body development.",
+                    "loadMin": 10,
+                    "loadMax": 18,
+                    "loadUnit": "kg",
+                    "loadPerHand": true,
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "isEmom": true,
+                    "supersetGroup": 1,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lunges",
+                      "Step-Ups",
+                      "Split Squats"
+                    ],
+                    "cues": [
+                      "Vertical shin",
+                      "Drive through heel"
+                    ],
+                    "isUnilateral": true
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Side Planks",
+                    "notes": "Core Recovery",
+                    "repsType": "time",
+                    "repsValue": 45,
+                    "repsUnit": "seconds",
+                    "repsPerSide": true,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60,
+                    "isEmom": true,
+                    "supersetGroup": 1
+                  },
+                  {
+                    "$ref": "cooldown-banded-pec-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-lat-prayer"
+                  },
+                  {
+                    "$ref": "cooldown-standing-quad-stretch"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "weekNumber": 14,
+            "description": null,
+            "focus": null,
+            "volumeLevel": "high",
+            "intensityLevel": "moderate",
+            "days": [
+              {
+                "dayNumber": 1,
+                "name": "Pull Day A",
+                "type": "strength",
+                "estimatedDuration": 57,
+                "description": null,
+                "exercises": [
+                  {
+                    "$ref": "warmup-rower-zone1"
+                  },
+                  {
+                    "$ref": "warmup-rower-zone2"
+                  },
+                  {
+                    "$ref": "warmup-rower-sprints"
+                  },
+                  {
+                    "$ref": "warmup-band-pull-aparts"
+                  },
+                  {
+                    "$ref": "warmup-band-external-rotations"
+                  },
+                  {
+                    "$ref": "warmup-scapular-pullups"
+                  },
+                  {
+                    "$ref": "warmup-passive-bar-hang"
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Pull-Ups",
+                    "notes": "Volume Increase",
+                    "repsType": "amrap",
+                    "repsValue": null,
+                    "repsModifier": 1,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lat Pulldowns",
+                      "Ring Rows",
+                      "Assisted Pull-Ups"
+                    ]
+                  },
+                  {
+                    "category": "accessory",
+                    "sets": 3,
+                    "exerciseName": "Feet-on-Floor Rows",
+                    "notes": "Accessory. Tempo 3-1-1-0. Maintain pulling volume.",
+                    "repsType": "reps",
+                    "repsValue": 10,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60,
+                    "alternatives": [
+                      "Ring Rows",
+                      "Dumbbell Rows"
+                    ]
+                  },
+                  {
+                    "$ref": "cooldown-passive-dead-hang"
+                  },
+                  {
+                    "category": "cooldown",
+                    "sets": 1,
+                    "exerciseName": "Butcher’s Block Stretch",
+                    "notes": "Cool-down. Targeting Lats/Triceps.",
+                    "repsType": "time",
+                    "repsValue": 60,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 0
+                  },
+                  {
+                    "$ref": "cooldown-cobra-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-wrist-extensor"
+                  }
+                ]
+              },
+              {
+                "$ref": "template-mobility-recovery",
+                "dayNumber": 2
+              },
+              {
+                "$ref": "template-lower-body-2",
+                "dayNumber": 3
+              },
+              {
+                "dayNumber": 5,
+                "name": "Pull Day B",
+                "type": "strength",
+                "estimatedDuration": 60,
+                "description": null,
+                "exercises": [
+                  {
+                    "$ref": "warmup-rower-zone1"
+                  },
+                  {
+                    "$ref": "warmup-rower-zone2"
+                  },
+                  {
+                    "$ref": "warmup-rower-sprints"
+                  },
+                  {
+                    "$ref": "warmup-band-pull-aparts"
+                  },
+                  {
+                    "$ref": "warmup-band-external-rotations"
+                  },
+                  {
+                    "$ref": "warmup-scapular-pullups"
+                  },
+                  {
+                    "$ref": "warmup-passive-bar-hang"
+                  },
+                  {
+                    "category": "main",
+                    "sets": 2,
+                    "exerciseName": "Weighted Pull-Ups",
+                    "notes": "Week 14 prescribed Weighted Pulls to 16kg.",
+                    "loadMin": 16,
+                    "loadMax": 16,
+                    "loadUnit": "kg",
+                    "repsType": "reps",
+                    "repsValue": 3,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lat Pulldowns",
+                      "Ring Rows",
+                      "Assisted Pull-Ups"
+                    ],
+                    "progressionNotes": "DOUBLE PROGRESSION RULE: Earn weight increase only when hitting top rep range for ALL sets with perfect form. (e.g. if 3x5 is goal, must hit 5,5,5 to add 1kg).",
+                    "cues": [
+                      "Full ROM",
+                      "Chin over bar",
+                      "Controlled descent"
+                    ]
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Weighted Dips",
+                    "notes": "Dip Governor Rule: If shoulder pinch occurs, switch immediately.",
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "loadMin": 5,
+                    "loadMax": 10,
+                    "loadUnit": "kg",
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Dips",
+                      "Bench Dips",
+                      "Chest Press Machine"
+                    ],
+                    "progressionNotes": "Double Progression Rule applies.",
+                    "cues": [
+                      "Shoulders down",
+                      "Don't flair elbows"
+                    ]
+                  },
+                  {
+                    "category": "accessory",
+                    "sets": 2,
+                    "exerciseName": "Chest Supported Row",
+                    "notes": "Accessory",
+                    "loadMin": 10,
+                    "loadMax": 15,
+                    "loadUnit": "kg",
+                    "loadPerHand": true,
+                    "repsType": "reps",
+                    "repsValue": 12,
+                    "restSeconds": 60
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Bulgarian Split Squat",
+                    "notes": "Left side. EMOM. Unilateral Leg Work. Squat pattern for balanced lower body development.",
+                    "loadMin": 10,
+                    "loadMax": 18,
+                    "loadUnit": "kg",
+                    "loadPerHand": true,
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "isEmom": true,
+                    "supersetGroup": 1,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lunges",
+                      "Step-Ups",
+                      "Split Squats"
+                    ],
+                    "cues": [
+                      "Vertical shin",
+                      "Drive through heel"
+                    ],
+                    "isUnilateral": true
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Bulgarian Split Squat",
+                    "notes": "Right side. EMOM. Unilateral Leg Work. Squat pattern for balanced lower body development.",
+                    "loadMin": 10,
+                    "loadMax": 18,
+                    "loadUnit": "kg",
+                    "loadPerHand": true,
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "isEmom": true,
+                    "supersetGroup": 1,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lunges",
+                      "Step-Ups",
+                      "Split Squats"
+                    ],
+                    "cues": [
+                      "Vertical shin",
+                      "Drive through heel"
+                    ],
+                    "isUnilateral": true
+                  },
+                  {
+                    "category": "core",
+                    "sets": 3,
+                    "exerciseName": "Dragon Flags OR Weighted V-Ups",
+                    "notes": "Core Hard. Dragon Flags (negatives) — conditional (only if tendons feel excellent); Otherwise: Weighted V-Ups 3×8-10.",
+                    "loadMin": 3,
+                    "loadMax": 5,
+                    "loadUnit": "kg",
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "restSeconds": 60,
+                    "isUnilateral": false,
+                    "supersetGroup": 1
+                  },
+                  {
+                    "$ref": "cooldown-banded-pec-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-lat-prayer"
+                  },
+                  {
+                    "$ref": "cooldown-standing-quad-stretch"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "weekNumber": 15,
+            "description": null,
+            "focus": null,
+            "volumeLevel": "high",
+            "intensityLevel": "high",
+            "days": [
+              {
+                "dayNumber": 1,
+                "name": "Pull Day A",
+                "type": "strength",
+                "estimatedDuration": 57,
+                "description": null,
+                "exercises": [
+                  {
+                    "$ref": "warmup-rower-zone1"
+                  },
+                  {
+                    "$ref": "warmup-rower-zone2"
+                  },
+                  {
+                    "$ref": "warmup-rower-sprints"
+                  },
+                  {
+                    "$ref": "warmup-band-pull-aparts"
+                  },
+                  {
+                    "$ref": "warmup-band-external-rotations"
+                  },
+                  {
+                    "$ref": "warmup-scapular-pullups"
+                  },
+                  {
+                    "$ref": "warmup-passive-bar-hang"
+                  },
+                  {
+                    "category": "main",
+                    "sets": 1,
+                    "exerciseName": "Pull-Ups",
+                    "notes": "All Out",
+                    "repsType": "amrap",
+                    "repsValue": null,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lat Pulldowns",
+                      "Ring Rows",
+                      "Assisted Pull-Ups"
+                    ]
+                  },
+                  {
+                    "category": "main",
+                    "sets": 2,
+                    "exerciseName": "Pull-Ups",
+                    "notes": "Back-off",
+                    "repsType": "submax",
+                    "repsValue": null,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lat Pulldowns",
+                      "Ring Rows",
+                      "Assisted Pull-Ups"
+                    ]
+                  },
+                  {
+                    "category": "accessory",
+                    "sets": 3,
+                    "exerciseName": "Feet-on-Floor Rows",
+                    "notes": "Accessory. Tempo 3-1-1-0. Maintain pulling volume.",
+                    "repsType": "reps",
+                    "repsValue": 10,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60,
+                    "alternatives": [
+                      "Ring Rows",
+                      "Dumbbell Rows"
+                    ]
+                  },
+                  {
+                    "$ref": "cooldown-passive-dead-hang"
+                  },
+                  {
+                    "category": "cooldown",
+                    "sets": 1,
+                    "exerciseName": "Butcher’s Block Stretch",
+                    "notes": "Cool-down. Targeting Lats/Triceps.",
+                    "repsType": "time",
+                    "repsValue": 60,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 0
+                  },
+                  {
+                    "$ref": "cooldown-cobra-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-wrist-extensor"
+                  }
+                ]
+              },
+              {
+                "$ref": "template-mobility-recovery",
+                "dayNumber": 2
+              },
+              {
+                "$ref": "template-lower-body-2",
+                "dayNumber": 3
+              },
+              {
+                "dayNumber": 5,
+                "name": "Pull Day B (Week 15 Peak / PR Attempt)",
+                "type": "strength",
+                "estimatedDuration": 55,
+                "description": null,
+                "exercises": [
+                  {
+                    "$ref": "warmup-rower-zone1"
+                  },
+                  {
+                    "$ref": "warmup-rower-zone2"
+                  },
+                  {
+                    "$ref": "warmup-rower-sprints"
+                  },
+                  {
+                    "$ref": "warmup-band-pull-aparts"
+                  },
+                  {
+                    "$ref": "warmup-band-external-rotations"
+                  },
+                  {
+                    "$ref": "warmup-scapular-pullups"
+                  },
+                  {
+                    "$ref": "warmup-passive-bar-hang"
+                  },
+                  {
+                    "category": "main",
+                    "sets": 1,
+                    "exerciseName": "Weighted Pull-Ups (PR attempt)",
+                    "notes": "Per doc Week 15 Weighted Pulls to 17.5kg (PR attempt). Apply double-progression safely.",
+                    "loadMin": 17.5,
+                    "loadMax": 17.5,
+                    "loadUnit": "kg",
+                    "repsType": "rm",
+                    "repsValue": 1,
+                    "restSeconds": 180,
+                    "alternatives": [
+                      "Lat Pulldowns",
+                      "Ring Rows",
+                      "Assisted Pull-Ups"
+                    ],
+                    "progressionNotes": "DOUBLE PROGRESSION RULE: Earn weight increase only when hitting top rep range for ALL sets with perfect form.",
+                    "cues": [
+                      "Full ROM",
+                      "Chin over bar",
+                      "Controlled descent"
+                    ]
+                  },
+                  {
+                    "category": "main",
+                    "sets": 4,
+                    "exerciseName": "Weighted Dips",
+                    "notes": "4×5 per doc; Dip Governor may alter exercise.",
+                    "loadMin": 5,
+                    "loadMax": 10,
+                    "loadUnit": "kg",
+                    "repsType": "reps",
+                    "repsValue": 5,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Straight Bar Dips",
+                      "Weighted Bench Dips"
+                    ],
+                    "progressionNotes": "Dip Governor Rule: If shoulder pinch occurs, switch immediately."
+                  },
+                  {
+                    "category": "accessory",
+                    "sets": 2,
+                    "exerciseName": "Chest Supported Row",
+                    "notes": "Accessory. Horizontal pull for balance.",
+                    "repsType": "reps",
+                    "repsValue": 12,
+                    "loadMin": 15,
+                    "loadMax": 25,
+                    "loadUnit": "kg",
+                    "loadPerHand": true,
+                    "restSeconds": 60
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Bulgarian Split Squat",
+                    "notes": "Left side. EMOM. Unilateral Leg Work. Squat pattern for balanced lower body development.",
+                    "loadMin": 10,
+                    "loadMax": 18,
+                    "loadUnit": "kg",
+                    "loadPerHand": true,
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "isEmom": true,
+                    "supersetGroup": 1,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lunges",
+                      "Step-Ups",
+                      "Split Squats"
+                    ],
+                    "cues": [
+                      "Vertical shin",
+                      "Drive through heel"
+                    ],
+                    "isUnilateral": true
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Bulgarian Split Squat",
+                    "notes": "Right side. EMOM. Unilateral Leg Work. Squat pattern for balanced lower body development.",
+                    "loadMin": 10,
+                    "loadMax": 18,
+                    "loadUnit": "kg",
+                    "loadPerHand": true,
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "isEmom": true,
+                    "supersetGroup": 1,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lunges",
+                      "Step-Ups",
+                      "Split Squats"
+                    ],
+                    "cues": [
+                      "Vertical shin",
+                      "Drive through heel"
+                    ],
+                    "isUnilateral": true
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Side Planks",
+                    "notes": "Core Recovery",
+                    "repsType": "time",
+                    "repsValue": 45,
+                    "repsUnit": "seconds",
+                    "repsPerSide": true,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60,
+                    "supersetGroup": 1
+                  },
+                  {
+                    "$ref": "cooldown-banded-pec-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-lat-prayer"
+                  },
+                  {
+                    "$ref": "cooldown-standing-quad-stretch"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "weekNumber": 16,
+            "description": null,
+            "focus": null,
+            "volumeLevel": "low",
+            "intensityLevel": "low",
+            "days": [
+              {
+                "dayNumber": 1,
+                "name": "Pull Day A",
+                "type": "strength",
+                "estimatedDuration": 56,
+                "description": null,
+                "exercises": [
+                  {
+                    "$ref": "warmup-rower-zone1"
+                  },
+                  {
+                    "$ref": "warmup-rower-zone2"
+                  },
+                  {
+                    "$ref": "warmup-rower-sprints"
+                  },
+                  {
+                    "$ref": "warmup-band-pull-aparts"
+                  },
+                  {
+                    "$ref": "warmup-band-external-rotations"
+                  },
+                  {
+                    "$ref": "warmup-scapular-pullups"
+                  },
+                  {
+                    "$ref": "warmup-passive-bar-hang"
+                  },
+                  {
+                    "category": "main",
+                    "sets": 2,
+                    "exerciseName": "Pull-Ups",
+                    "notes": "Deload",
+                    "repsType": "amrap",
+                    "repsValue": null,
+                    "repsModifier": 4,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lat Pulldowns",
+                      "Ring Rows",
+                      "Assisted Pull-Ups"
+                    ]
+                  },
+                  {
+                    "category": "accessory",
+                    "sets": 2,
+                    "exerciseName": "Feet-on-Floor Rows",
+                    "notes": "Deload. Accessory. Tempo 3-1-1-0. Maintain pulling volume.",
+                    "repsType": "reps",
+                    "repsValue": 10,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 60,
+                    "alternatives": [
+                      "Ring Rows",
+                      "Dumbbell Rows"
+                    ]
+                  },
+                  {
+                    "$ref": "cooldown-passive-dead-hang"
+                  },
+                  {
+                    "category": "cooldown",
+                    "sets": 1,
+                    "exerciseName": "Butcher’s Block Stretch",
+                    "notes": "Cool-down. Targeting Lats/Triceps.",
+                    "repsType": "time",
+                    "repsValue": 60,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 0
+                  },
+                  {
+                    "$ref": "cooldown-cobra-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-wrist-extensor"
+                  }
+                ]
+              },
+              {
+                "$ref": "template-mobility-recovery",
+                "dayNumber": 2
+              },
+              {
+                "dayNumber": 3,
+                "name": "Lower Body",
+                "type": "strength",
+                "estimatedDuration": 12,
+                "description": null,
+                "exercises": [
+                  {
+                    "category": "mobility",
+                    "sets": 1,
+                    "exerciseName": "Light Mobility",
+                    "notes": "Recovery",
+                    "repsType": "time",
+                    "repsValue": 1200,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 90
+                  },
+                  {
+                    "$ref": "cooldown-couch-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-jefferson-curl"
+                  },
+                  {
+                    "$ref": "cooldown-90-90-hip-rotations"
+                  }
+                ]
+              },
+              {
+                "$ref": "template-pull-day-b",
+                "dayNumber": 5
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "phaseNumber": 5,
+        "name": "Peaking Phase",
+        "description": "Taper and prepare for testing",
+        "startWeek": 17,
+        "endWeek": 19,
+        "focus": "deload",
+        "weeks": [
+          {
+            "weekNumber": 17,
+            "description": null,
+            "focus": null,
+            "volumeLevel": "moderate",
+            "intensityLevel": "moderate",
+            "days": [
+              {
+                "dayNumber": 1,
+                "name": "Pull Day A (Tapered Intensity)",
+                "type": "strength",
+                "estimatedDuration": 62,
+                "description": null,
+                "exercises": [
+                  {
+                    "$ref": "warmup-rower-zone1"
+                  },
+                  {
+                    "$ref": "warmup-rower-zone2"
+                  },
+                  {
+                    "$ref": "warmup-rower-sprints"
+                  },
+                  {
+                    "$ref": "warmup-band-pull-aparts"
+                  },
+                  {
+                    "$ref": "warmup-band-external-rotations"
+                  },
+                  {
+                    "$ref": "warmup-scapular-pullups"
+                  },
+                  {
+                    "$ref": "warmup-passive-bar-hang"
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Pull-Ups",
+                    "notes": "Tapering",
+                    "repsType": "amrap",
+                    "repsValue": null,
+                    "repsModifier": 1,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lat Pulldowns",
+                      "Ring Rows",
+                      "Assisted Pull-Ups"
+                    ]
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Feet-on-Floor Rows",
+                    "notes": null,
+                    "repsType": "reps",
+                    "repsValue": 10,
+                    "tempoEccentric": 3,
+                    "tempoPauseBottom": 1,
+                    "tempoConcentric": 1,
+                    "tempoPauseTop": 0,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Dumbbell Rows",
+                      "Cable Rows",
+                      "Inverted Rows"
+                    ]
+                  },
+                  {
+                    "$ref": "cooldown-passive-dead-hang"
+                  },
+                  {
+                    "category": "cooldown",
+                    "sets": 1,
+                    "exerciseName": "Butcher’s Block Stretch",
+                    "notes": "Cool-down. Targeting Lats/Triceps.",
+                    "repsType": "time",
+                    "repsValue": 60,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 0
+                  },
+                  {
+                    "$ref": "cooldown-cobra-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-wrist-extensor"
+                  }
+                ]
+              },
+              {
+                "$ref": "template-mobility-recovery",
+                "dayNumber": 2
+              },
+              {
+                "$ref": "template-lower-body-3",
+                "dayNumber": 3
+              },
+              {
+                "dayNumber": 5,
+                "name": "Pull Day B (Archer Negative Peak)",
+                "type": "strength",
+                "estimatedDuration": 60,
+                "description": null,
+                "exercises": [
+                  {
+                    "$ref": "warmup-rower-zone1"
+                  },
+                  {
+                    "$ref": "warmup-rower-zone2"
+                  },
+                  {
+                    "$ref": "warmup-rower-sprints"
+                  },
+                  {
+                    "$ref": "warmup-band-pull-aparts"
+                  },
+                  {
+                    "$ref": "warmup-band-external-rotations"
+                  },
+                  {
+                    "$ref": "warmup-scapular-pullups"
+                  },
+                  {
+                    "$ref": "warmup-passive-bar-hang"
+                  },
+                  {
+                    "category": "main",
+                    "sets": 4,
+                    "exerciseName": "Archer Negatives",
+                    "notes": "4×2/side; 5-6s eccentric; no pause at bottom.",
+                    "repsType": "reps",
+                    "repsValue": 2,
+                    "repsPerSide": true,
+                    "tempoEccentric": 5,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 120
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Bulgarian Split Squat",
+                    "notes": "Left side. EMOM. Unilateral Leg Work. Squat pattern for balanced lower body development.",
+                    "loadMin": 10,
+                    "loadMax": 18,
+                    "loadUnit": "kg",
+                    "loadPerHand": true,
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "isEmom": true,
+                    "supersetGroup": 1,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lunges",
+                      "Step-Ups",
+                      "Split Squats"
+                    ],
+                    "cues": [
+                      "Vertical shin",
+                      "Drive through heel"
+                    ],
+                    "isUnilateral": true
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Bulgarian Split Squat",
+                    "notes": "Right side. EMOM. Unilateral Leg Work. Squat pattern for balanced lower body development.",
+                    "loadMin": 10,
+                    "loadMax": 18,
+                    "loadUnit": "kg",
+                    "loadPerHand": true,
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "isEmom": true,
+                    "supersetGroup": 1,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lunges",
+                      "Step-Ups",
+                      "Split Squats"
+                    ],
+                    "cues": [
+                      "Vertical shin",
+                      "Drive through heel"
+                    ],
+                    "isUnilateral": true
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Weighted V-Ups",
+                    "notes": "Core Hard. Hard Core. Keep biceps by ears.",
+                    "loadMin": 3,
+                    "loadMax": 5,
+                    "loadUnit": "kg",
+                    "repsType": "reps",
+                    "repsValue": 10,
+                    "restSeconds": 60,
+                    "progressionNotes": "Start 1.25kg. Progress only with perfect form.",
+                    "supersetGroup": 1
+                  },
+                  {
+                    "$ref": "cooldown-banded-pec-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-lat-prayer"
+                  },
+                  {
+                    "$ref": "cooldown-standing-quad-stretch"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "weekNumber": 18,
+            "description": "Reduce volume by 20% from baseline per doc.",
+            "focus": null,
+            "volumeLevel": "moderate",
+            "intensityLevel": "moderate",
+            "days": [
+              {
+                "dayNumber": 1,
+                "name": "Pull Day A (Taper)",
+                "type": "strength",
+                "estimatedDuration": 57,
+                "description": "Reduce volume by 20% from baseline per doc.",
+                "exercises": [
+                  {
+                    "$ref": "warmup-rower-zone1"
+                  },
+                  {
+                    "$ref": "warmup-rower-zone2"
+                  },
+                  {
+                    "$ref": "warmup-rower-sprints"
+                  },
+                  {
+                    "$ref": "warmup-band-pull-aparts"
+                  },
+                  {
+                    "$ref": "warmup-band-external-rotations"
+                  },
+                  {
+                    "$ref": "warmup-scapular-pullups"
+                  },
+                  {
+                    "$ref": "warmup-passive-bar-hang"
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Pull-Ups",
+                    "notes": "Taper",
+                    "repsType": "amrap",
+                    "repsValue": null,
+                    "repsModifier": 20,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lat Pulldowns",
+                      "Ring Rows",
+                      "Assisted Pull-Ups"
+                    ]
+                  },
+                  {
+                    "$ref": "cooldown-passive-dead-hang"
+                  },
+                  {
+                    "category": "cooldown",
+                    "sets": 1,
+                    "exerciseName": "Butcher’s Block Stretch",
+                    "notes": "Cool-down. Targeting Lats/Triceps.",
+                    "repsType": "time",
+                    "repsValue": 60,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 0
+                  },
+                  {
+                    "$ref": "cooldown-cobra-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-wrist-extensor"
+                  }
+                ]
+              },
+              {
+                "$ref": "template-mobility-recovery",
+                "dayNumber": 2
+              },
+              {
+                "$ref": "template-lower-body-3",
+                "dayNumber": 3
+              },
+              {
+                "dayNumber": 5,
+                "name": "Pull Day B",
+                "type": "strength",
+                "estimatedDuration": 57,
+                "description": null,
+                "exercises": [
+                  {
+                    "$ref": "warmup-rower-zone1"
+                  },
+                  {
+                    "$ref": "warmup-rower-zone2"
+                  },
+                  {
+                    "$ref": "warmup-rower-sprints"
+                  },
+                  {
+                    "$ref": "warmup-band-pull-aparts"
+                  },
+                  {
+                    "$ref": "warmup-band-external-rotations"
+                  },
+                  {
+                    "$ref": "warmup-scapular-pullups"
+                  },
+                  {
+                    "$ref": "warmup-passive-bar-hang"
+                  },
+                  {
+                    "category": "main",
+                    "sets": 5,
+                    "exerciseName": "Archer Negatives",
+                    "notes": "5×3/side; 5–6s eccentric.",
+                    "repsType": "reps",
+                    "repsValue": 3,
+                    "repsPerSide": true,
+                    "tempoEccentric": 5,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 120
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Bulgarian Split Squat",
+                    "notes": "Left side. EMOM. Unilateral Leg Work. Squat pattern for balanced lower body development.",
+                    "loadMin": 10,
+                    "loadMax": 18,
+                    "loadUnit": "kg",
+                    "loadPerHand": true,
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "isEmom": true,
+                    "supersetGroup": 1,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lunges",
+                      "Step-Ups",
+                      "Split Squats"
+                    ],
+                    "cues": [
+                      "Vertical shin",
+                      "Drive through heel"
+                    ],
+                    "isUnilateral": true
+                  },
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "Bulgarian Split Squat",
+                    "notes": "Right side. EMOM. Unilateral Leg Work. Squat pattern for balanced lower body development.",
+                    "loadMin": 10,
+                    "loadMax": 18,
+                    "loadUnit": "kg",
+                    "loadPerHand": true,
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "isEmom": true,
+                    "supersetGroup": 1,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lunges",
+                      "Step-Ups",
+                      "Split Squats"
+                    ],
+                    "cues": [
+                      "Vertical shin",
+                      "Drive through heel"
+                    ],
+                    "isUnilateral": true
+                  },
+                  {
+                    "category": "core",
+                    "sets": 3,
+                    "exerciseName": "Weighted Hollow Rocks",
+                    "notes": "EMOM. Arms straight overhead. If lower back arches, drop weight immediately.",
+                    "loadMin": 3,
+                    "loadMax": 5,
+                    "loadUnit": "kg",
+                    "repsType": "reps",
+                    "repsValue": 15,
+                    "isEmom": true,
+                    "supersetGroup": 1,
+                    "restSeconds": 120,
+                    "progressionNotes": "Start 1.25/2.5kg. Move to 5kg only when holding shape perfectly for 45s."
+                  },
+                  {
+                    "$ref": "cooldown-banded-pec-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-lat-prayer"
+                  },
+                  {
+                    "$ref": "cooldown-standing-quad-stretch"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "weekNumber": 19,
+            "description": "The calm before the test. 50% volume.",
+            "focus": null,
+            "volumeLevel": "low",
+            "intensityLevel": "low",
+            "days": [
+              {
+                "dayNumber": 1,
+                "name": "Deload Day",
+                "type": "recovery",
+                "estimatedDuration": 45,
+                "description": null,
+                "exercises": [
+                  {
+                    "$ref": "warmup-rower-zone1"
+                  },
+                  {
+                    "$ref": "warmup-rower-zone2"
+                  },
+                  {
+                    "$ref": "warmup-rower-sprints",
+                    "sets": 2,
+                    "notes": "Warm-up - Reduced. Min 5: 3 x 10s Sprints to wake up CNS."
+                  },
+                  {
+                    "$ref": "warmup-band-pull-aparts",
+                    "repsValue": 15
+                  },
+                  {
+                    "$ref": "warmup-band-external-rotations",
+                    "repsValue": 10
+                  },
+                  {
+                    "$ref": "warmup-scapular-pullups",
+                    "sets": 2,
+                    "notes": "Warm-up - Reduced. Global Tendon Prep. 3s ISO-HOLD at top. No bouncy reps."
+                  },
+                  {
+                    "$ref": "warmup-passive-bar-hang"
+                  },
+                  {
+                    "category": "main",
+                    "sets": 2,
+                    "exerciseName": "Pull-Ups",
+                    "notes": "Deload - 50% volume, stay fresh",
+                    "repsType": "reps",
+                    "repsValue": 5,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lat Pulldowns",
+                      "Ring Rows",
+                      "Assisted Pull-Ups"
+                    ]
+                  },
+                  {
+                    "$ref": "cooldown-passive-dead-hang"
+                  },
+                  {
+                    "$ref": "cooldown-butchers-block",
+                    "notes": "Cool-down"
+                  },
+                  {
+                    "$ref": "cooldown-cobra-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-wrist-extensor"
+                  }
+                ]
+              },
+              {
+                "dayNumber": 2,
+                "name": "Mobility & Recovery",
+                "type": "mobility",
+                "estimatedDuration": 25,
+                "description": null,
+                "exercises": [
+                  {
+                    "category": "mobility",
+                    "sets": 1,
+                    "exerciseName": "Knee-to-Wall Ankle Mob",
+                    "notes": "Mobility",
+                    "repsType": "time",
+                    "repsValue": 120,
+                    "repsUnit": "seconds",
+                    "repsPerSide": true,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 90
+                  },
+                  {
+                    "category": "mobility",
+                    "sets": 2,
+                    "exerciseName": "Tibialis Wall Raises",
+                    "notes": "Mobility - Reduced",
+                    "repsType": "reps",
+                    "repsMin": 15,
+                    "repsMax": 20,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 90
+                  },
+                  {
+                    "category": "mobility",
+                    "sets": 2,
+                    "exerciseName": "Deep Squat Iso-Hold",
+                    "notes": "Mobility",
+                    "repsType": "time",
+                    "repsValue": 30,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 90
+                  },
+                  {
+                    "category": "mobility",
+                    "sets": 1,
+                    "exerciseName": "Band Internal Rotations",
+                    "notes": "Pre-hab - Reduced",
+                    "loadMin": 1,
+                    "loadMax": 1,
+                    "loadUnit": "band",
+                    "repsType": "reps",
+                    "repsValue": 15,
+                    "repsPerSide": true,
+                    "restSeconds": 90
+                  },
+                  {
+                    "category": "mobility",
+                    "sets": 1,
+                    "exerciseName": "Mobility Flow",
+                    "notes": "Recovery",
+                    "repsType": "time",
+                    "repsValue": 600,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 90
+                  },
+                  {
+                    "category": "core",
+                    "sets": 2,
+                    "exerciseName": "Pallof Press",
+                    "notes": "Core - Reduced",
+                    "loadMin": 1,
+                    "loadMax": 1,
+                    "loadUnit": "band",
+                    "repsType": "reps",
+                    "repsValue": 10,
+                    "restSeconds": 60
+                  },
+                  {
+                    "category": "cooldown",
+                    "sets": 1,
+                    "exerciseName": "Child's Pose",
+                    "notes": "Cool-down",
+                    "repsType": "time",
+                    "repsValue": 120,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 0
+                  },
+                  {
+                    "category": "cooldown",
+                    "sets": 1,
+                    "exerciseName": "Box Breathing (4-4-4-4)",
+                    "notes": "Cool-down. 4s In, 4s Hold, 4s Out, 4s Hold.",
+                    "repsType": "time",
+                    "repsValue": 180,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 0
+                  }
+                ]
+              },
+              {
+                "dayNumber": 3,
+                "name": "Lower Body",
+                "type": "mobility",
+                "estimatedDuration": 20,
+                "description": null,
+                "exercises": [
+                  {
+                    "category": "mobility",
+                    "sets": 1,
+                    "exerciseName": "Mobility Flow",
+                    "notes": "Recovery",
+                    "repsType": "time",
+                    "repsValue": 900,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 90
+                  },
+                  {
+                    "$ref": "cooldown-couch-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-jefferson-curl",
+                    "repsValue": 90
+                  },
+                  {
+                    "$ref": "cooldown-90-90-hip-rotations"
+                  }
+                ]
+              },
+              {
+                "dayNumber": 5,
+                "name": "Pull Day B",
+                "type": "strength",
+                "estimatedDuration": 40,
+                "description": null,
+                "exercises": [
+                  {
+                    "$ref": "warmup-rower-zone1"
+                  },
+                  {
+                    "$ref": "warmup-rower-zone2"
+                  },
+                  {
+                    "$ref": "warmup-rower-sprints",
+                    "sets": 2,
+                    "notes": "Warm-up - Reduced. Min 5: 3 x 10s Sprints to wake up CNS."
+                  },
+                  {
+                    "$ref": "warmup-band-pull-aparts",
+                    "repsValue": 15
+                  },
+                  {
+                    "$ref": "warmup-band-external-rotations",
+                    "repsValue": 10
+                  },
+                  {
+                    "$ref": "warmup-scapular-pullups",
+                    "sets": 2,
+                    "notes": "Warm-up - Reduced. Global Tendon Prep. 3s ISO-HOLD at top. No bouncy reps."
+                  },
+                  {
+                    "$ref": "warmup-passive-bar-hang"
+                  },
+                  {
+                    "category": "main",
+                    "sets": 2,
+                    "exerciseName": "Archer Negatives",
+                    "notes": "Deload - 50% volume, 5s Descent",
+                    "repsType": "reps",
+                    "repsValue": 2,
+                    "repsPerSide": true,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 120
+                  },
+                  {
+                    "category": "main",
+                    "sets": 2,
+                    "exerciseName": "Bulgarian Split Squat",
+                    "notes": "Left side. Deload. Unilateral Leg Work. Squat pattern for balanced lower body development.",
+                    "loadMin": 8,
+                    "loadMax": 12,
+                    "loadUnit": "kg",
+                    "loadPerHand": true,
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "isEmom": true,
+                    "supersetGroup": 1,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lunges",
+                      "Step-Ups",
+                      "Split Squats"
+                    ],
+                    "cues": [
+                      "Vertical shin",
+                      "Drive through heel"
+                    ],
+                    "isUnilateral": true
+                  },
+                  {
+                    "category": "main",
+                    "sets": 2,
+                    "exerciseName": "Bulgarian Split Squat",
+                    "notes": "Right side. Deload. Unilateral Leg Work. Squat pattern for balanced lower body development.",
+                    "loadMin": 8,
+                    "loadMax": 12,
+                    "loadUnit": "kg",
+                    "loadPerHand": true,
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "isEmom": true,
+                    "supersetGroup": 1,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lunges",
+                      "Step-Ups",
+                      "Split Squats"
+                    ],
+                    "cues": [
+                      "Vertical shin",
+                      "Drive through heel"
+                    ],
+                    "isUnilateral": true
+                  },
+                  {
+                    "category": "core",
+                    "sets": 2,
+                    "exerciseName": "Weighted Hollow Rocks",
+                    "notes": "Deload. Arms straight overhead. If lower back arches, drop weight immediately.",
+                    "loadMin": 2,
+                    "loadMax": 3,
+                    "loadUnit": "kg",
+                    "repsType": "reps",
+                    "repsValue": 12,
+                    "isEmom": true,
+                    "supersetGroup": 1,
+                    "restSeconds": 120,
+                    "progressionNotes": "Deload weight."
+                  },
+                  {
+                    "$ref": "cooldown-banded-pec-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-lat-prayer"
+                  },
+                  {
+                    "$ref": "cooldown-standing-quad-stretch"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "phaseNumber": 6,
+        "name": "Testing & Reload",
+        "description": "Performance testing and preparation for next cycle",
+        "startWeek": 20,
+        "endWeek": 21,
+        "focus": "test",
+        "weeks": [
+          {
+            "weekNumber": 20,
+            "description": "TEST WEEK (doc-prescribed tests)",
+            "focus": null,
+            "volumeLevel": "low",
+            "intensityLevel": "peak",
+            "days": [
+              {
+                "dayNumber": 1,
+                "name": "Endurance Test Day",
+                "type": "test",
+                "estimatedDuration": 29,
+                "description": "Battery Conservation Warm-up: 5 min rower + 10 scap pulls + 3 reps @50% + 1 rep @75% + rest 4 min",
+                "exercises": [
+                  {
+                    "$ref": "warmup-rower-zone1"
+                  },
+                  {
+                    "$ref": "warmup-rower-zone2"
+                  },
+                  {
+                    "category": "warmup",
+                    "sets": 1,
+                    "exerciseName": "Scapular Pull-Ups",
+                    "notes": "Warm-up. Global Tendon Prep. 3s ISO-HOLD at top. No bouncy reps.",
+                    "repsType": "reps",
+                    "repsValue": 10,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 30,
+                    "alternatives": [
+                      "Lat Pulldowns",
+                      "Ring Rows",
+                      "Assisted Pull-Ups"
+                    ],
+                    "cues": [
+                      "Straight arms",
+                      "Depress scapula",
+                      "Hold 3s"
+                    ]
+                  },
+                  {
+                    "category": "warmup",
+                    "sets": 3,
+                    "exerciseName": "Pull-Ups",
+                    "notes": "Warm-up",
+                    "repsType": "effort",
+                    "repsValue": 50,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 30,
+                    "alternatives": [
+                      "Lat Pulldowns",
+                      "Ring Rows",
+                      "Assisted Pull-Ups"
+                    ]
+                  },
+                  {
+                    "category": "warmup",
+                    "sets": 1,
+                    "exerciseName": "Pull-Ups",
+                    "notes": "Warm-up",
+                    "repsType": "effort",
+                    "repsValue": 75,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 30,
+                    "alternatives": [
+                      "Lat Pulldowns",
+                      "Ring Rows",
+                      "Assisted Pull-Ups"
+                    ]
+                  },
+                  {
+                    "category": "main",
+                    "sets": 1,
+                    "exerciseName": "Rest",
+                    "notes": "Battery Saver. Recovery interval.",
+                    "repsType": "time",
+                    "repsValue": 240,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 120
+                  },
+                  {
+                    "category": "main",
+                    "sets": 1,
+                    "exerciseName": "Max Reps Pull-Ups (BW)",
+                    "notes": "TEST. Test to technical failure.",
+                    "repsType": "max",
+                    "repsValue": null,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lat Pulldowns",
+                      "Ring Rows",
+                      "Assisted Pull-Ups"
+                    ]
+                  },
+                  {
+                    "category": "main",
+                    "sets": 1,
+                    "exerciseName": "Max Reps Dips",
+                    "notes": "TEST. Dip Governor Rule: If shoulder pinch occurs, switch immediately.",
+                    "repsType": "max",
+                    "repsValue": null,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Push-Ups",
+                      "Bench Dips",
+                      "Chest Press Machine"
+                    ],
+                    "progressionNotes": "Double Progression Rule applies.",
+                    "cues": [
+                      "Shoulders down",
+                      "Don't flair elbows"
+                    ]
+                  }
+                ]
+              },
+              {
+                "dayNumber": 2,
+                "name": "Mobility & Recovery",
+                "type": "mobility",
+                "estimatedDuration": 2,
+                "description": null,
+                "exercises": [
+                  {
+                    "category": "mobility",
+                    "sets": 1,
+                    "exerciseName": "Rest",
+                    "notes": "Recovery. Recovery interval.",
+                    "repsType": "none",
+                    "repsValue": null,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 90
+                  }
+                ]
+              },
+              {
+                "dayNumber": 3,
+                "name": "Lower Body",
+                "type": "mobility",
+                "estimatedDuration": 2,
+                "description": null,
+                "exercises": [
+                  {
+                    "category": "mobility",
+                    "sets": 1,
+                    "exerciseName": "Rest",
+                    "notes": "Recovery. Recovery interval.",
+                    "repsType": "none",
+                    "repsValue": null,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 90
+                  }
+                ]
+              },
+              {
+                "dayNumber": 4,
+                "name": "Day 4",
+                "type": "mobility",
+                "estimatedDuration": 2,
+                "description": null,
+                "exercises": [
+                  {
+                    "category": "mobility",
+                    "sets": 1,
+                    "exerciseName": "Rest",
+                    "notes": "Recovery. Recovery interval.",
+                    "repsType": "none",
+                    "repsValue": null,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 90
+                  }
+                ]
+              },
+              {
+                "dayNumber": 5,
+                "name": "Strength Test Day",
+                "type": "test",
+                "estimatedDuration": 31,
+                "description": "Battery Conservation Warm-up: same as Day 1",
+                "exercises": [
+                  {
+                    "$ref": "warmup-rower-zone1"
+                  },
+                  {
+                    "$ref": "warmup-rower-zone2"
+                  },
+                  {
+                    "category": "warmup",
+                    "sets": 1,
+                    "exerciseName": "Scapular Pull-Ups",
+                    "notes": "Warm-up. Global Tendon Prep. 3s ISO-HOLD at top. No bouncy reps.",
+                    "repsType": "reps",
+                    "repsValue": 10,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 30,
+                    "alternatives": [
+                      "Lat Pulldowns",
+                      "Ring Rows",
+                      "Assisted Pull-Ups"
+                    ],
+                    "cues": [
+                      "Straight arms",
+                      "Depress scapula",
+                      "Hold 3s"
+                    ]
+                  },
+                  {
+                    "category": "warmup",
+                    "sets": 3,
+                    "exerciseName": "Pull-Ups",
+                    "notes": "Warm-up",
+                    "repsType": "effort",
+                    "repsValue": 50,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 30,
+                    "alternatives": [
+                      "Lat Pulldowns",
+                      "Ring Rows",
+                      "Assisted Pull-Ups"
+                    ]
+                  },
+                  {
+                    "category": "warmup",
+                    "sets": 1,
+                    "exerciseName": "Pull-Ups",
+                    "notes": "Warm-up",
+                    "repsType": "effort",
+                    "repsValue": 75,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 30,
+                    "alternatives": [
+                      "Lat Pulldowns",
+                      "Ring Rows",
+                      "Assisted Pull-Ups"
+                    ]
+                  },
+                  {
+                    "category": "main",
+                    "sets": 1,
+                    "exerciseName": "Rest",
+                    "notes": "Battery Saver. Recovery interval.",
+                    "repsType": "time",
+                    "repsValue": 240,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 120
+                  },
+                  {
+                    "category": "main",
+                    "sets": 1,
+                    "exerciseName": "3RM Weighted Pull-Up",
+                    "notes": "TEST",
+                    "loadMin": 15,
+                    "loadMax": 20,
+                    "loadUnit": "kg",
+                    "repsType": "rm",
+                    "repsValue": 3,
+                    "restSeconds": 120
+                  },
+                  {
+                    "category": "main",
+                    "sets": 1,
+                    "exerciseName": "5RM Weighted Push-Up",
+                    "notes": "TEST",
+                    "loadMin": 10,
+                    "loadMax": 15,
+                    "loadUnit": "kg",
+                    "repsType": "rm",
+                    "repsValue": 5,
+                    "restSeconds": 120
+                  },
+                  {
+                    "category": "main",
+                    "sets": 1,
+                    "exerciseName": "Max Quality Archer Negatives",
+                    "notes": "TEST",
+                    "repsType": "max",
+                    "repsValue": null,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 120
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "weekNumber": 21,
+            "description": "Post-Program Reload. NO Weighted Dips, NO Weighted Pulls.",
+            "focus": null,
+            "volumeLevel": "low",
+            "intensityLevel": "low",
+            "days": [
+              {
+                "dayNumber": 1,
+                "name": "Reload Week (60% of Week 1)",
+                "type": "recovery",
+                "estimatedDuration": 12,
+                "description": null,
+                "exercises": [
+                  {
+                    "category": "main",
+                    "sets": 2,
+                    "exerciseName": "Pull-Up Ladders",
+                    "notes": "60% Vol (Reload). Ladders: 1, 2, 3 reps... Volume baseline. Focus on perfect form.",
+                    "repsType": "ladder",
+                    "repsValue": [
+                      1,
+                      2,
+                      3
+                    ],
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 120,
+                    "progressionNotes": "Volume accumulation phase. Do not fail sets."
+                  },
+                  {
+                    "category": "main",
+                    "sets": 2,
+                    "exerciseName": "Ring Rows",
+                    "notes": "60% Vol (Reload). Tempo 2-1-1-0. Stop if sharp pain.",
+                    "repsType": "reps",
+                    "repsValue": 15,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Dumbbell Rows",
+                      "Cable Rows",
+                      "Inverted Rows"
+                    ]
+                  },
+                  {
+                    "category": "main",
+                    "sets": 2,
+                    "exerciseName": "Incline Push-Ups",
+                    "notes": "60% Vol (Reload). Tempo 2-1-1-0.",
+                    "repsType": "reps",
+                    "repsValue": 10,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Dips",
+                      "Incline Push-Ups",
+                      "Diamond Push-Ups"
+                    ]
+                  },
+                  {
+                    "category": "main",
+                    "sets": 2,
+                    "exerciseName": "Hollow Rocks",
+                    "notes": "60% Vol (Reload). Ground-Based. Watch for elbow tightness.",
+                    "repsType": "time",
+                    "repsValue": 25,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "V-Ups",
+                      "Dead Bugs"
+                    ]
+                  }
+                ]
+              },
+              {
+                "dayNumber": 2,
+                "name": "Mobility & Recovery",
+                "type": "mobility",
+                "estimatedDuration": 14,
+                "description": null,
+                "exercises": [
+                  {
+                    "category": "mobility",
+                    "sets": 1,
+                    "exerciseName": "Knee-to-Wall Ankle Mob",
+                    "notes": "Mobility",
+                    "repsType": "time",
+                    "repsValue": 120,
+                    "repsUnit": "seconds",
+                    "repsPerSide": true,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 90
+                  },
+                  {
+                    "category": "mobility",
+                    "sets": 3,
+                    "exerciseName": "Tibialis Wall Raises",
+                    "notes": "Mobility",
+                    "repsType": "reps",
+                    "repsMin": 15,
+                    "repsMax": 20,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 90
+                  },
+                  {
+                    "category": "mobility",
+                    "sets": 2,
+                    "exerciseName": "Deep Squat Iso-Hold",
+                    "notes": "Mobility",
+                    "repsType": "time",
+                    "repsValue": 30,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 90
+                  },
+                  {
+                    "category": "mobility",
+                    "sets": 2,
+                    "exerciseName": "Band Internal Rotations",
+                    "notes": "Pre-hab",
+                    "loadMin": 1,
+                    "loadMax": 1,
+                    "loadUnit": "band",
+                    "repsType": "reps",
+                    "repsValue": 20,
+                    "repsPerSide": true,
+                    "restSeconds": 90
+                  },
+                  {
+                    "category": "mobility",
+                    "sets": 1,
+                    "exerciseName": "Mobility Flow",
+                    "notes": "Recovery",
+                    "repsType": "time",
+                    "repsValue": 600,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 90
+                  }
+                ]
+              },
+              {
+                "dayNumber": 3,
+                "name": "Lower Body",
+                "type": "strength",
+                "estimatedDuration": 14,
+                "description": null,
+                "exercises": [
+                  {
+                    "category": "main",
+                    "sets": 3,
+                    "exerciseName": "RDL",
+                    "notes": "60% (Reload). Posterior chain focus.",
+                    "loadMin": 60,
+                    "loadMax": 80,
+                    "loadUnit": "kg",
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "restSeconds": 120
+                  },
+                  {
+                    "category": "main",
+                    "sets": 2,
+                    "exerciseName": "Weighted Glute Bridge",
+                    "notes": "Light. Tempo 2-1-1-0. Squeeze glutes hard at top.",
+                    "loadMin": 40,
+                    "loadMax": 60,
+                    "loadUnit": "kg",
+                    "repsType": "reps",
+                    "repsValue": 10,
+                    "restSeconds": 120,
+                    "cues": [
+                      "No lumbar hyperextension"
+                    ]
+                  },
+                  {
+                    "$ref": "main-goblet-squats",
+                    "sets": 2,
+                    "notes": "Light. Reinforce healthy squat patterns. Ankle mobility focus."
+                  },
+                  {
+                    "$ref": "accessory-face-pulls",
+                    "category": "main",
+                    "sets": 2,
+                    "restSeconds": 120,
+                    "notes": "Light. Tempo 2-1-1-0. Upper back health."
+                  }
+                ]
+              },
+              {
+                "dayNumber": 5,
+                "name": "Pull Day B",
+                "type": "strength",
+                "estimatedDuration": 46,
+                "description": "Reload version of Week 1 Pull Day B. 60% volume. NO weighted pulls or dips.",
+                "exercises": [
+                  {
+                    "$ref": "warmup-rower-zone1"
+                  },
+                  {
+                    "$ref": "warmup-rower-zone2"
+                  },
+                  {
+                    "$ref": "warmup-rower-sprints",
+                    "sets": 2,
+                    "notes": "Warm-up. Reload: 2 x 10s Sprints to wake up CNS without fatigue."
+                  },
+                  {
+                    "$ref": "warmup-band-pull-aparts",
+                    "notes": "Warm-up. Tendon prep."
+                  },
+                  {
+                    "$ref": "warmup-band-external-rotations",
+                    "notes": "Warm-up. Pin elbow to ribcage using a towel roll."
+                  },
+                  {
+                    "$ref": "warmup-scapular-pullups",
+                    "sets": 2,
+                    "notes": "Warm-up. Depress scapula and hold 3s at top."
+                  },
+                  {
+                    "$ref": "warmup-passive-bar-hang",
+                    "notes": "Warm-up. Light passive hang for tissue decompression.",
+                    "repsValue": 20
+                  },
+                  {
+                    "category": "skill",
+                    "sets": 2,
+                    "exerciseName": "Skill: HSPU Volume (Reload)",
+                    "notes": "60% Vol (Reload). Practice the groove, stop far from failure.",
+                    "repsType": "reps",
+                    "repsValue": 3,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 90
+                  },
+                  {
+                    "category": "main",
+                    "sets": 2,
+                    "exerciseName": "Pull-Ups",
+                    "notes": "Reload. NO weighted pulls. Tempo 2-1-1. Focus on perfect reps.",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "repsType": "reps",
+                    "repsValue": 5,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lat Pulldowns",
+                      "Ring Rows",
+                      "Assisted Pull-Ups"
+                    ],
+                    "cues": [
+                      "Full ROM",
+                      "Chin over bar",
+                      "Controlled descent"
+                    ]
+                  },
+                  {
+                    "category": "main",
+                    "sets": 2,
+                    "exerciseName": "Dips",
+                    "notes": "Reload. Bodyweight only. Dip Governor Rule: stop if shoulder pinch.",
+                    "repsType": "reps",
+                    "repsValue": 8,
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Push-Ups",
+                      "Bench Dips",
+                      "Chest Press Machine"
+                    ],
+                    "cues": [
+                      "Shoulders down",
+                      "Don't flair elbows"
+                    ]
+                  },
+                  {
+                    "category": "main",
+                    "sets": 2,
+                    "exerciseName": "Bulgarian Split Squat",
+                    "notes": "Left side. EMOM. Alternating EMOM (Min 1 Left, Min 2 Right). Light loading.",
+                    "loadMin": 6,
+                    "loadMax": 12,
+                    "loadUnit": "kg",
+                    "loadPerHand": true,
+                    "repsType": "reps",
+                    "repsValue": 6,
+                    "isEmom": true,
+                    "supersetGroup": 1,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lunges",
+                      "Step-Ups",
+                      "Split Squats"
+                    ],
+                    "cues": [
+                      "Vertical shin",
+                      "Drive through heel"
+                    ],
+                    "isUnilateral": true
+                  },
+                  {
+                    "category": "main",
+                    "sets": 2,
+                    "exerciseName": "Bulgarian Split Squat",
+                    "notes": "Right side. EMOM. Alternating EMOM (Min 1 Left, Min 2 Right). Light loading.",
+                    "loadMin": 6,
+                    "loadMax": 12,
+                    "loadUnit": "kg",
+                    "loadPerHand": true,
+                    "repsType": "reps",
+                    "repsValue": 6,
+                    "isEmom": true,
+                    "supersetGroup": 1,
+                    "restSeconds": 120,
+                    "alternatives": [
+                      "Lunges",
+                      "Step-Ups",
+                      "Split Squats"
+                    ],
+                    "cues": [
+                      "Vertical shin",
+                      "Drive through heel"
+                    ],
+                    "isUnilateral": true
+                  },
+                  {
+                    "category": "core",
+                    "sets": 2,
+                    "exerciseName": "Hollow Rocks",
+                    "notes": "EMOM. Pair with Bulgarians. Bodyweight only for tissue reset.",
+                    "repsType": "time",
+                    "repsValue": 20,
+                    "repsUnit": "seconds",
+                    "loadMin": 0,
+                    "loadMax": 0,
+                    "loadUnit": "bodyweight",
+                    "isEmom": true,
+                    "supersetGroup": 1,
+                    "restSeconds": 120
+                  },
+                  {
+                    "$ref": "cooldown-banded-pec-stretch"
+                  },
+                  {
+                    "$ref": "cooldown-lat-prayer"
+                  },
+                  {
+                    "$ref": "cooldown-standing-quad-stretch"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "dayTemplates": [
+      {
+        "id": "template-mobility-recovery",
+        "dayNumber": 2,
+        "name": "Mobility & Recovery",
+        "type": "mobility",
+        "estimatedDuration": 25,
+        "description": null,
+        "exercises": [
+          {
+            "category": "mobility",
+            "sets": 1,
+            "exerciseName": "Knee-to-Wall Ankle Mob",
+            "notes": "Mobility",
+            "repsType": "time",
+            "repsValue": 120,
+            "repsUnit": "seconds",
+            "repsPerSide": true,
+            "loadMin": 0,
+            "loadMax": 0,
+            "loadUnit": "bodyweight",
+            "restSeconds": 0
+          },
+          {
+            "category": "mobility",
+            "sets": 3,
+            "exerciseName": "Tibialis Wall Raises",
+            "notes": "Mobility",
+            "repsType": "reps",
+            "repsMin": 15,
+            "repsMax": 20,
+            "loadMin": 0,
+            "loadMax": 0,
+            "loadUnit": "bodyweight",
+            "restSeconds": 0
+          },
+          {
+            "category": "mobility",
+            "sets": 2,
+            "exerciseName": "Deep Squat Iso-Hold",
+            "notes": "Mobility",
+            "repsType": "time",
+            "repsValue": 30,
+            "repsUnit": "seconds",
+            "loadMin": 0,
+            "loadMax": 0,
+            "loadUnit": "bodyweight",
+            "restSeconds": 0
+          },
+          {
+            "category": "mobility",
+            "sets": 2,
+            "exerciseName": "Band Internal Rotations",
+            "notes": "Pre-hab",
+            "loadMin": 1,
+            "loadMax": 1,
+            "loadUnit": "band",
+            "repsType": "reps",
+            "repsValue": 20,
+            "repsPerSide": true,
+            "restSeconds": 0
+          },
+          {
+            "category": "mobility",
+            "sets": 1,
+            "exerciseName": "Mobility Flow",
+            "notes": "Recovery",
+            "repsType": "time",
+            "repsValue": 600,
+            "repsUnit": "seconds",
+            "loadMin": 0,
+            "loadMax": 0,
+            "loadUnit": "bodyweight",
+            "restSeconds": 0
+          },
+          {
+            "category": "core",
+            "sets": 3,
+            "exerciseName": "Pallof Press",
+            "notes": "Core",
+            "loadMin": 1,
+            "loadMax": 1,
+            "loadUnit": "band",
+            "repsType": "reps",
+            "repsValue": 12,
+            "restSeconds": 60
+          },
+          {
+            "category": "cooldown",
+            "sets": 1,
+            "exerciseName": "Child’s Pose",
+            "notes": "Cool-down. Focus on breathing into lower back.",
+            "repsType": "time",
+            "repsValue": 120,
+            "repsUnit": "seconds",
+            "loadMin": 0,
+            "loadMax": 0,
+            "loadUnit": "bodyweight",
+            "restSeconds": 0
+          },
+          {
+            "category": "cooldown",
+            "sets": 1,
+            "exerciseName": "Box Breathing (4-4-4-4)",
+            "notes": "Cool-down. 4s In, 4s Hold, 4s Out, 4s Hold.",
+            "repsType": "time",
+            "repsValue": 180,
+            "repsUnit": "seconds",
+            "loadMin": 0,
+            "loadMax": 0,
+            "loadUnit": "bodyweight",
+            "restSeconds": 0
+          }
+        ]
+      },
+      {
+        "id": "template-lower-body",
+        "dayNumber": 3,
+        "name": "Lower Body",
+        "type": "strength",
+        "estimatedDuration": 30,
+        "description": null,
+        "exercises": [
+          {
+            "category": "main",
+            "sets": 4,
+            "exerciseName": "RDL",
+            "notes": "Hamstring Focus. Posterior chain focus.",
+            "loadMin": 60,
+            "loadMax": 80,
+            "loadUnit": "kg",
+            "repsType": "reps",
+            "repsValue": 10,
+            "restSeconds": 180
+          },
+          {
+            "category": "accessory",
+            "sets": 3,
+            "exerciseName": "Rower Leg Curls (2-Leg)",
+            "notes": "Accessory. Protocol: Min 1-2: Easy (Zone 1). Min 3-4: Moderate (Zone 2). Min 5: 3x10s Sprints.",
+            "repsType": "reps",
+            "repsValue": 10,
+            "loadMin": 0,
+            "loadMax": 0,
+            "loadUnit": "bodyweight",
+            "restSeconds": 60
+          },
+          {
+            "$ref": "main-goblet-squats"
+          },
+          {
+            "category": "accessory",
+            "sets": 3,
+            "exerciseName": "Back Extensions",
+            "notes": "Accessory. Tempo 2-1-1-0.",
+            "repsType": "reps",
+            "repsValue": 12,
+            "loadMin": 0,
+            "loadMax": 0,
+            "loadUnit": "bodyweight",
+            "restSeconds": 60
+          },
+          {
+            "$ref": "cooldown-couch-stretch"
+          },
+          {
+            "$ref": "cooldown-jefferson-curl"
+          },
+          {
+            "$ref": "cooldown-90-90-hip-rotations"
+          }
+        ]
+      },
+      {
+        "id": "template-pull-day-b",
+        "dayNumber": 5,
+        "name": "Pull Day B",
+        "type": "strength",
+        "estimatedDuration": 52,
+        "description": null,
+        "exercises": [
+          {
+            "$ref": "warmup-rower-zone1",
+            "restSeconds": 0
+          },
+          {
+            "$ref": "warmup-rower-zone2",
+            "restSeconds": 0
+          },
+          {
+            "$ref": "warmup-rower-sprints",
+            "restSeconds": 60
+          },
+          {
+            "$ref": "warmup-band-pull-aparts",
+            "restSeconds": 45
+          },
+          {
+            "$ref": "warmup-band-external-rotations",
+            "restSeconds": 45
+          },
+          {
+            "$ref": "warmup-scapular-pullups",
+            "restSeconds": 60
+          },
+          {
+            "$ref": "warmup-passive-bar-hang",
+            "restSeconds": 60
+          },
+          {
+            "category": "main",
+            "sets": 2,
+            "exerciseName": "Weighted Pull-Ups",
+            "notes": "Easy. Primary Goal: Build elite pulling strength.",
+            "loadMin": 5,
+            "loadMax": 10,
+            "loadUnit": "kg",
+            "repsType": "reps",
+            "repsValue": 3,
+            "restSeconds": 180,
+            "progressionNotes": "DOUBLE PROGRESSION RULE: Earn weight increase only when hitting top rep range for ALL sets with perfect form. (e.g. if 3x5 is goal, must hit 5,5,5 to add 1kg).",
+            "alternatives": [
+              "Lat Pulldowns",
+              "Banded Pull-downs"
+            ],
+            "cues": [
+              "Full ROM",
+              "Chin over bar",
+              "Controlled descent"
+            ]
+          },
+          {
+            "category": "main",
+            "sets": 3,
+            "exerciseName": "Bulgarian Split Squat",
+            "notes": "Left side. EMOM. Unilateral Leg Work. Squat pattern for balanced lower body development.",
+            "loadMin": 10,
+            "loadMax": 18,
+            "loadUnit": "kg",
+            "loadPerHand": true,
+            "repsType": "reps",
+            "repsValue": 8,
+            "isEmom": true,
+            "supersetGroup": 1,
+            "restSeconds": 120,
+            "alternatives": [
+              "Lunges",
+              "Step-Ups",
+              "Split Squats"
+            ],
+            "cues": [
+              "Vertical shin",
+              "Drive through heel"
+            ],
+            "isUnilateral": true
+          },
+          {
+            "category": "main",
+            "sets": 3,
+            "exerciseName": "Bulgarian Split Squat",
+            "notes": "Right side. EMOM. Unilateral Leg Work. Squat pattern for balanced lower body development.",
+            "loadMin": 10,
+            "loadMax": 18,
+            "loadUnit": "kg",
+            "loadPerHand": true,
+            "repsType": "reps",
+            "repsValue": 8,
+            "isEmom": true,
+            "supersetGroup": 1,
+            "restSeconds": 120,
+            "alternatives": [
+              "Lunges",
+              "Step-Ups",
+              "Split Squats"
+            ],
+            "cues": [
+              "Vertical shin",
+              "Drive through heel"
+            ],
+            "isUnilateral": true
+          },
+          {
+            "category": "core",
+            "sets": 3,
+            "exerciseName": "Weighted Hollow Rocks",
+            "notes": "EMOM. Arms straight overhead. If lower back arches, drop weight immediately.",
+            "loadMin": 3,
+            "loadMax": 5,
+            "loadUnit": "kg",
+            "repsType": "reps",
+            "repsValue": 15,
+            "isEmom": true,
+            "supersetGroup": 1,
+            "restSeconds": 120,
+            "progressionNotes": "Start 1.25/2.5kg. Move to 5kg only when holding shape perfectly for 45s."
+          },
+          {
+            "$ref": "cooldown-banded-pec-stretch"
+          },
+          {
+            "$ref": "cooldown-lat-prayer"
+          },
+          {
+            "$ref": "cooldown-standing-quad-stretch"
+          }
+        ]
+      },
+      {
+        "id": "template-lower-body-1",
+        "dayNumber": 3,
+        "name": "Lower Body",
+        "type": "strength",
+        "estimatedDuration": 24,
+        "description": null,
+        "exercises": [
+          {
+            "category": "main",
+            "sets": 3,
+            "exerciseName": "Single Leg RDL",
+            "notes": "Unilateral. Posterior chain focus.",
+            "loadMin": 8,
+            "loadMax": 12,
+            "loadUnit": "kg",
+            "loadPerHand": true,
+            "repsType": "reps",
+            "repsValue": 8,
+            "repsPerSide": true,
+            "restSeconds": 180
+          },
+          {
+            "$ref": "main-goblet-squats"
+          },
+          {
+            "$ref": "accessory-face-pulls"
+          },
+          {
+            "$ref": "cooldown-couch-stretch"
+          },
+          {
+            "$ref": "cooldown-jefferson-curl"
+          },
+          {
+            "$ref": "cooldown-90-90-hip-rotations"
+          }
+        ]
+      },
+      {
+        "id": "template-lower-body-2",
+        "dayNumber": 3,
+        "name": "Lower Body",
+        "type": "strength",
+        "estimatedDuration": 26,
+        "description": null,
+        "exercises": [
+          {
+            "category": "main",
+            "sets": 4,
+            "exerciseName": "RDL",
+            "notes": "Accumulation Heavy. Posterior chain focus.",
+            "loadMin": 60,
+            "loadMax": 80,
+            "loadUnit": "kg",
+            "repsType": "reps",
+            "repsValue": 10,
+            "restSeconds": 180
+          },
+          {
+            "$ref": "main-goblet-squats"
+          },
+          {
+            "$ref": "accessory-face-pulls"
+          },
+          {
+            "$ref": "cooldown-couch-stretch"
+          },
+          {
+            "$ref": "cooldown-jefferson-curl"
+          },
+          {
+            "$ref": "cooldown-90-90-hip-rotations"
+          }
+        ]
+      },
+      {
+        "id": "template-lower-body-3",
+        "dayNumber": 3,
+        "name": "Lower Body",
+        "type": "strength",
+        "estimatedDuration": 12,
+        "description": null,
+        "exercises": [
+          {
+            "category": "mobility",
+            "sets": 1,
+            "exerciseName": "Mobility Flow",
+            "notes": "Recovery",
+            "repsType": "time",
+            "repsValue": 1200,
+            "repsUnit": "seconds",
+            "loadMin": 0,
+            "loadMax": 0,
+            "loadUnit": "bodyweight",
+            "restSeconds": 0
+          },
+          {
+            "$ref": "cooldown-couch-stretch"
+          },
+          {
+            "$ref": "cooldown-jefferson-curl"
+          },
+          {
+            "$ref": "cooldown-90-90-hip-rotations"
+          }
+        ]
+      }
+    ],
+    "exerciseTemplates": [
+      {
+        "id": "warmup-rower-zone1",
+        "exerciseName": "Rower (Zone 1)",
+        "category": "warmup",
+        "sets": 1,
+        "notes": "Warm-up. Min 1-2: Easy pace to warm up (Zone 1).",
+        "repsType": "time",
+        "repsValue": 120,
+        "repsUnit": "seconds",
+        "loadMin": 0,
+        "loadMax": 0,
+        "loadUnit": "bodyweight",
+        "restSeconds": 30
+      },
+      {
+        "id": "warmup-rower-zone2",
+        "exerciseName": "Rower (Zone 2)",
+        "category": "warmup",
+        "sets": 1,
+        "notes": "Warm-up. Min 3-4: Moderate intensity (Zone 2).",
+        "repsType": "time",
+        "repsValue": 120,
+        "repsUnit": "seconds",
+        "loadMin": 0,
+        "loadMax": 0,
+        "loadUnit": "bodyweight",
+        "restSeconds": 30
+      },
+      {
+        "id": "warmup-rower-sprints",
+        "exerciseName": "Rower Sprints",
+        "category": "warmup",
+        "sets": 3,
+        "notes": "Warm-up. Min 5: 3 x 10s Sprints to wake up CNS.",
+        "repsType": "time",
+        "repsValue": 10,
+        "repsUnit": "seconds",
+        "loadMin": 0,
+        "loadMax": 0,
+        "loadUnit": "bodyweight",
+        "restSeconds": 30
+      },
+      {
+        "id": "warmup-band-pull-aparts",
+        "exerciseName": "Band Pull-Aparts",
+        "category": "warmup",
+        "sets": 1,
+        "notes": "Warm-up. Global Tendon Prep.",
+        "loadMin": 1,
+        "loadMax": 1,
+        "loadUnit": "band",
+        "repsType": "reps",
+        "repsValue": 20,
+        "restSeconds": 30
+      },
+      {
+        "id": "warmup-band-external-rotations",
+        "exerciseName": "Band External Rotations",
+        "category": "warmup",
+        "sets": 1,
+        "notes": "Warm-up. Global Tendon Prep. Pin elbow to ribcage using a towel roll.",
+        "loadMin": 1,
+        "loadMax": 1,
+        "loadUnit": "band",
+        "repsType": "reps",
+        "repsValue": 15,
+        "repsPerSide": true,
+        "restSeconds": 30,
+        "cues": [
+          "Elbow pinned",
+          "Rotate away from belly"
+        ]
+      },
+      {
+        "id": "warmup-scapular-pullups",
+        "exerciseName": "Scapular Pull-Ups (3s ISO-HOLD)",
+        "category": "warmup",
+        "sets": 3,
+        "notes": "Warm-up. Global Tendon Prep. 3s ISO-HOLD at top. No bouncy reps.",
+        "repsType": "reps",
+        "repsValue": 5,
+        "loadMin": 0,
+        "loadMax": 0,
+        "loadUnit": "bodyweight",
+        "restSeconds": 30,
+        "alternatives": [
+          "Lat Pulldowns",
+          "Ring Rows",
+          "Assisted Pull-Ups"
+        ],
+        "cues": [
+          "Straight arms",
+          "Depress scapula",
+          "Hold 3s"
+        ]
+      },
+      {
+        "id": "warmup-passive-bar-hang",
+        "exerciseName": "Passive Bar Hang",
+        "category": "warmup",
+        "sets": 1,
+        "notes": "Warm-up. Global Tendon Prep. Passive hang.",
+        "repsType": "time",
+        "repsValue": 30,
+        "repsUnit": "seconds",
+        "loadMin": 0,
+        "loadMax": 0,
+        "loadUnit": "bodyweight",
+        "restSeconds": 30,
+        "cues": [
+          "Relax shoulders",
+          "Decompress spine"
+        ]
+      },
+      {
+        "id": "cooldown-passive-dead-hang",
+        "exerciseName": "Passive Dead Hang",
+        "category": "cooldown",
+        "sets": 1,
+        "notes": "Cool-down. Spinal decompression.",
+        "repsType": "time",
+        "repsValue": 60,
+        "repsUnit": "seconds",
+        "loadMin": 0,
+        "loadMax": 0,
+        "loadUnit": "bodyweight",
+        "restSeconds": 0
+      },
+      {
+        "id": "cooldown-butchers-block",
+        "exerciseName": "Butcher's Block Stretch",
+        "category": "cooldown",
+        "sets": 1,
+        "notes": "Cool-down. Targeting Lats/Triceps.",
+        "repsType": "time",
+        "repsValue": 60,
+        "repsUnit": "seconds",
+        "loadMin": 0,
+        "loadMax": 0,
+        "loadUnit": "bodyweight",
+        "restSeconds": 0
+      },
+      {
+        "id": "cooldown-cobra-stretch",
+        "exerciseName": "Cobra Stretch",
+        "category": "cooldown",
+        "sets": 1,
+        "notes": "Cool-down. Releasing abs.",
+        "repsType": "time",
+        "repsValue": 60,
+        "repsUnit": "seconds",
+        "loadMin": 0,
+        "loadMax": 0,
+        "loadUnit": "bodyweight",
+        "restSeconds": 0
+      },
+      {
+        "id": "cooldown-wrist-extensor",
+        "exerciseName": "Wrist Extensor Stretch",
+        "category": "cooldown",
+        "sets": 1,
+        "notes": "Cool-down. Forearm health.",
+        "repsType": "time",
+        "repsValue": 30,
+        "repsUnit": "seconds",
+        "repsPerSide": true,
+        "loadMin": 0,
+        "loadMax": 0,
+        "loadUnit": "bodyweight",
+        "restSeconds": 0
+      },
+      {
+        "id": "cooldown-banded-pec-stretch",
+        "exerciseName": "Banded Pec Stretch",
+        "category": "cooldown",
+        "sets": 1,
+        "notes": "Cool-down. Release tension from dips.",
+        "repsType": "time",
+        "repsValue": 60,
+        "repsUnit": "seconds",
+        "repsPerSide": true,
+        "loadMin": 0,
+        "loadMax": 0,
+        "loadUnit": "bodyweight",
+        "restSeconds": 0
+      },
+      {
+        "id": "cooldown-lat-prayer",
+        "exerciseName": "Lat Prayer",
+        "category": "cooldown",
+        "sets": 1,
+        "notes": "Cool-down. Lat release.",
+        "repsType": "time",
+        "repsValue": 60,
+        "repsUnit": "seconds",
+        "loadMin": 0,
+        "loadMax": 0,
+        "loadUnit": "bodyweight",
+        "restSeconds": 0
+      },
+      {
+        "id": "cooldown-standing-quad-stretch",
+        "exerciseName": "Standing Quad Stretch",
+        "category": "cooldown",
+        "sets": 1,
+        "notes": "Cool-down. Quad release.",
+        "repsType": "time",
+        "repsValue": 60,
+        "repsUnit": "seconds",
+        "repsPerSide": true,
+        "loadMin": 0,
+        "loadMax": 0,
+        "loadUnit": "bodyweight",
+        "restSeconds": 0
+      },
+      {
+        "id": "cooldown-couch-stretch",
+        "exerciseName": "Couch Stretch",
+        "category": "cooldown",
+        "sets": 1,
+        "notes": "Cool-down. Hip flexor release.",
+        "repsType": "time",
+        "repsValue": 90,
+        "repsUnit": "seconds",
+        "repsPerSide": true,
+        "loadMin": 0,
+        "loadMax": 0,
+        "loadUnit": "bodyweight",
+        "restSeconds": 0
+      },
+      {
+        "id": "cooldown-jefferson-curl",
+        "exerciseName": "Light Weighted Jefferson Curl",
+        "category": "cooldown",
+        "sets": 1,
+        "notes": "Cool-down. Spinal segmentation. Tuck chin, roll down one vertebra at a time.",
+        "loadMin": 5,
+        "loadMax": 10,
+        "loadUnit": "kg",
+        "repsType": "time",
+        "repsValue": 120,
+        "repsUnit": "seconds",
+        "restSeconds": 0,
+        "cues": [
+          "Use empty bar or light DB",
+          "Do not use PVC",
+          "Passive pull"
+        ]
+      },
+      {
+        "id": "cooldown-90-90-hip-rotations",
+        "exerciseName": "90/90 Hip Rotations",
+        "category": "cooldown",
+        "sets": 1,
+        "notes": "Cool-down. Hip mobility.",
+        "repsType": "reps",
+        "repsValue": 10,
+        "repsPerSide": true,
+        "loadMin": 0,
+        "loadMax": 0,
+        "loadUnit": "bodyweight",
+        "restSeconds": 0
+      },
+      {
+        "id": "main-goblet-squats",
+        "exerciseName": "Goblet Squats",
+        "category": "main",
+        "sets": 3,
+        "notes": "Pattern Maint. Reinforce healthy squat patterns. Ankle mobility focus.",
+        "loadMin": 16,
+        "loadMax": 24,
+        "loadUnit": "kg",
+        "repsType": "reps",
+        "repsValue": 10,
+        "restSeconds": 120,
+        "cues": [
+          "Upright torso",
+          "Knees track toes"
+        ]
+      },
+      {
+        "id": "accessory-face-pulls",
+        "exerciseName": "Face Pulls",
+        "category": "accessory",
+        "sets": 3,
+        "notes": "Accessory. Tempo 2-1-1-0. Upper back health.",
+        "loadMin": 2,
+        "loadMax": 2,
+        "loadUnit": "band",
+        "repsType": "reps",
+        "repsValue": 15,
+        "restSeconds": 60
+      },
+      {
+        "id": "core-hollow-rocks",
+        "exerciseName": "Hollow Rocks",
+        "category": "core",
+        "sets": 3,
+        "notes": "Core Work. Tempo controlled. Lower back must stay glued.",
+        "loadMin": 0,
+        "loadMax": 0,
+        "loadUnit": "bodyweight",
+        "repsType": "reps",
+        "repsMin": 12,
+        "repsMax": 15,
+        "restSeconds": 60,
+        "alternatives": [
+          "V-Ups",
+          "Dead Bugs"
+        ]
+      },
+      {
+        "id": "core-weighted-hollow-rocks",
+        "exerciseName": "Weighted Hollow Rocks",
+        "category": "core",
+        "sets": 3,
+        "notes": "Core Work. Arms straight overhead. If lower back arches, drop weight immediately.",
+        "loadMin": 1.25,
+        "loadMax": 2.5,
+        "loadUnit": "kg",
+        "repsType": "reps",
+        "repsMin": 12,
+        "repsMax": 15,
+        "restSeconds": 60,
+        "progressionNotes": "Start 1.25/2.5kg. Move to 5kg only when holding shape perfectly for 45s."
+      }
+    ]
+  }
+}

--- a/workout-plan-v2.2.schema.json
+++ b/workout-plan-v2.2.schema.json
@@ -1,0 +1,742 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/tomaszwojcikowski/tracker/workout-plan-v2.2.schema.json",
+  "title": "Workout Plan v2.2.0",
+  "description": "Schema for the Tracker application workout plan format v2.2.0 with exercise templates. Exercise templates allow defining common exercises once and referencing them throughout the plan, with optional field overrides.",
+  "type": "object",
+  "required": ["formatVersion", "plan"],
+  "properties": {
+    "formatVersion": {
+      "type": "string",
+      "pattern": "^2\\.\\d+\\.\\d+$",
+      "description": "Format specification version (semantic versioning, must be 2.x.x)"
+    },
+    "plan": {
+      "$ref": "#/definitions/plan"
+    }
+  },
+  "definitions": {
+    "plan": {
+      "type": "object",
+      "required": ["id", "name", "durationWeeks", "phases"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Unique identifier for the plan"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Human-readable plan name"
+        },
+        "description": {
+          "type": ["string", "null"],
+          "description": "Detailed description of the training plan"
+        },
+        "author": {
+          "type": ["string", "null"],
+          "description": "Creator of the plan"
+        },
+        "createdDate": {
+          "type": ["string", "null"],
+          "description": "ISO 8601 date when plan was created"
+        },
+        "lastModified": {
+          "type": ["string", "null"],
+          "description": "ISO 8601 date of last modification"
+        },
+        "version": {
+          "type": ["string", "null"],
+          "description": "Plan version (independent of format version)"
+        },
+        "durationWeeks": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Total duration in weeks"
+        },
+        "goals": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Training goals"
+        },
+        "targetLevel": {
+          "type": ["string", "null"],
+          "enum": ["beginner", "intermediate", "advanced", "elite", null],
+          "description": "Intended experience level"
+        },
+        "equipment": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Required equipment list"
+        },
+        "programRules": {
+          "type": "object",
+          "description": "Program-specific rules and constraints",
+          "additionalProperties": true
+        },
+        "exerciseTemplates": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/exerciseTemplate" },
+          "description": "Reusable exercise templates that can be referenced by $ref (v2.2+). Define common exercises once with all their default properties."
+        },
+        "dayTemplates": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/dayTemplate" },
+          "description": "Reusable day templates that can be referenced by $ref (v2.1+)"
+        },
+        "phases": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/definitions/phase" },
+          "description": "Array of training phases (mesocycles)"
+        }
+      }
+    },
+    "exerciseTemplate": {
+      "type": "object",
+      "required": ["id", "exerciseName"],
+      "description": "A reusable exercise template. All exercise properties except 'id' and 'exerciseName' are optional and can be overridden when referenced.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[a-z0-9_-]+$",
+          "description": "Unique identifier for this exercise template (lowercase, alphanumeric, hyphens, underscores)"
+        },
+        "exerciseName": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Full exercise name as displayed to user"
+        },
+        "exerciseId": {
+          "type": ["string", "null"],
+          "description": "Reference to exercise in library"
+        },
+        "category": {
+          "type": ["string", "null"],
+          "enum": ["warmup", "main", "accessory", "cooldown", "mobility", "skill", "core", null],
+          "description": "Default exercise category"
+        },
+        "sets": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Default number of sets"
+        },
+        "restSeconds": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "description": "Default rest between sets in seconds"
+        },
+        "rpe": {
+          "type": ["number", "null"],
+          "minimum": 1,
+          "maximum": 10,
+          "description": "Default target RPE"
+        },
+        "notes": {
+          "type": ["string", "null"],
+          "description": "Default training prescription and coaching cues"
+        },
+        "alternatives": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Array of alternative exercise names or IDs"
+        },
+        "progressionNotes": {
+          "type": ["string", "null"],
+          "description": "How to progress this exercise"
+        },
+        "videoUrl": {
+          "type": ["string", "null"],
+          "format": "uri",
+          "description": "Link to demonstration video"
+        },
+        "cues": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Array of coaching cue strings"
+        },
+        "loadMin": {
+          "type": ["number", "null"],
+          "minimum": 0,
+          "description": "Default minimum weight value"
+        },
+        "loadMax": {
+          "type": ["number", "null"],
+          "minimum": 0,
+          "description": "Default maximum weight value"
+        },
+        "loadUnit": {
+          "type": ["string", "null"],
+          "enum": ["kg", "lb", "band", "bodyweight", "percent", null],
+          "description": "Default load unit"
+        },
+        "loadPerHand": {
+          "type": ["boolean", "null"],
+          "description": "True if load is per hand (for dumbbell exercises)"
+        },
+        "repsType": {
+          "type": ["string", "null"],
+          "enum": ["reps", "time", "ladder", "amrap", "rm", "max", "effort", "submax", "none", null],
+          "description": "Default reps type"
+        },
+        "repsValue": {
+          "oneOf": [
+            { "type": "integer", "minimum": 0 },
+            { "type": "array", "items": { "type": "integer", "minimum": 1 } },
+            { "type": "null" }
+          ],
+          "description": "Default primary value (count, seconds, or ladder steps array)"
+        },
+        "repsMin": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "description": "Default minimum reps for rep ranges"
+        },
+        "repsMax": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "description": "Default maximum reps for rep ranges"
+        },
+        "repsUnit": {
+          "type": ["string", "null"],
+          "enum": ["seconds", "minutes", null],
+          "description": "Default unit for time-based reps"
+        },
+        "repsPerSide": {
+          "type": ["boolean", "null"],
+          "description": "True if reps are per side"
+        },
+        "repsModifier": {
+          "type": ["integer", "null"],
+          "description": "Modifier for AMRAP (e.g., -1 for leave 1 rep in reserve)"
+        },
+        "tempoEccentric": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "description": "Eccentric phase duration in seconds"
+        },
+        "tempoPauseBottom": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "description": "Pause at bottom position in seconds"
+        },
+        "tempoConcentric": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "description": "Concentric phase duration in seconds"
+        },
+        "tempoPauseTop": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "description": "Pause at top position in seconds"
+        },
+        "isEmom": {
+          "type": ["boolean", "null"],
+          "description": "Whether this exercise uses EMOM timing"
+        },
+        "isUnilateral": {
+          "type": ["boolean", "null"],
+          "description": "Whether this exercise is performed per side"
+        },
+        "supersetGroup": {
+          "type": ["integer", "null"],
+          "minimum": 1,
+          "description": "Default superset group ID"
+        }
+      }
+    },
+    "dayTemplate": {
+      "type": "object",
+      "required": ["id", "exercises"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[a-z0-9_-]+$",
+          "description": "Unique identifier for this template (lowercase, alphanumeric, hyphens, underscores)"
+        },
+        "dayNumber": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 7,
+          "description": "Default day number"
+        },
+        "name": {
+          "type": ["string", "null"],
+          "description": "Template name"
+        },
+        "type": {
+          "type": ["string", "null"],
+          "enum": ["strength", "mobility", "cardio", "skill", "recovery", "rest", "test", null],
+          "description": "Session type"
+        },
+        "estimatedDuration": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "description": "Estimated duration in minutes"
+        },
+        "description": {
+          "type": ["string", "null"],
+          "description": "Template description"
+        },
+        "exercises": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/exerciseOrRef" },
+          "description": "Array of exercise specifications or references"
+        }
+      }
+    },
+    "phase": {
+      "type": "object",
+      "required": ["phaseNumber", "name", "startWeek", "endWeek", "weeks"],
+      "properties": {
+        "phaseNumber": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Sequential phase number (1-indexed)"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Phase name"
+        },
+        "description": {
+          "type": ["string", "null"],
+          "description": "Phase description and goals"
+        },
+        "startWeek": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "First week of phase (1-indexed)"
+        },
+        "endWeek": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Last week of phase (inclusive)"
+        },
+        "focus": {
+          "type": ["string", "null"],
+          "enum": ["volume", "intensity", "skill", "deload", "test", "technique", null],
+          "description": "Primary focus"
+        },
+        "weeks": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/definitions/week" },
+          "description": "Array of week objects"
+        }
+      }
+    },
+    "week": {
+      "type": "object",
+      "required": ["weekNumber", "days"],
+      "properties": {
+        "weekNumber": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Week number within the entire plan (1-indexed)"
+        },
+        "description": {
+          "type": ["string", "null"],
+          "description": "Week description or focus"
+        },
+        "focus": {
+          "type": ["string", "null"],
+          "description": "Primary focus for the week"
+        },
+        "volumeLevel": {
+          "type": ["string", "null"],
+          "enum": ["low", "moderate", "high", "peak", null],
+          "description": "Relative volume"
+        },
+        "intensityLevel": {
+          "type": ["string", "null"],
+          "enum": ["low", "moderate", "high", "peak", null],
+          "description": "Relative intensity"
+        },
+        "days": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/day" },
+          "description": "Array of training days"
+        }
+      }
+    },
+    "day": {
+      "type": "object",
+      "required": ["dayNumber"],
+      "oneOf": [
+        {
+          "properties": {
+            "dayNumber": { "$ref": "#/definitions/dayNumber" },
+            "id": { "$ref": "#/definitions/dayId" },
+            "name": { "$ref": "#/definitions/dayName" },
+            "type": { "$ref": "#/definitions/dayType" },
+            "estimatedDuration": { "$ref": "#/definitions/dayEstimatedDuration" },
+            "description": { "$ref": "#/definitions/dayDescription" },
+            "exercises": {
+              "type": "array",
+              "items": { "$ref": "#/definitions/exerciseOrRef" },
+              "description": "Array of exercise specifications or references"
+            }
+          },
+          "required": ["dayNumber", "exercises"],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "dayNumber": { "$ref": "#/definitions/dayNumber" },
+            "$ref": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Reference to a day template or previously defined day by ID"
+            },
+            "name": { "$ref": "#/definitions/dayName" },
+            "description": { "$ref": "#/definitions/dayDescription" }
+          },
+          "required": ["dayNumber", "$ref"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "dayNumber": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 7,
+      "description": "Day number within the week (1-7)"
+    },
+    "dayId": {
+      "type": ["string", "null"],
+      "pattern": "^[a-z0-9_-]+$",
+      "description": "Unique identifier for referencing this day (v2.1+)"
+    },
+    "dayName": {
+      "type": ["string", "null"],
+      "description": "Descriptive name for the session"
+    },
+    "dayType": {
+      "type": ["string", "null"],
+      "enum": ["strength", "mobility", "cardio", "skill", "recovery", "rest", "test", null],
+      "description": "Session type"
+    },
+    "dayEstimatedDuration": {
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "description": "Estimated duration in minutes"
+    },
+    "dayDescription": {
+      "type": ["string", "null"],
+      "description": "Session description or notes"
+    },
+    "exerciseOrRef": {
+      "oneOf": [
+        { "$ref": "#/definitions/exercise" },
+        { "$ref": "#/definitions/exerciseRef" }
+      ]
+    },
+    "exerciseRef": {
+      "type": "object",
+      "required": ["$ref"],
+      "description": "Reference to an exercise template with optional field overrides. Any field specified here will override the template's default value.",
+      "properties": {
+        "$ref": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Reference to an exercise template ID defined in exerciseTemplates"
+        },
+        "exerciseName": {
+          "type": "string",
+          "description": "Override exercise name (e.g., for left/right side variations)"
+        },
+        "category": {
+          "type": ["string", "null"],
+          "enum": ["warmup", "main", "accessory", "cooldown", "mobility", "skill", "core", null],
+          "description": "Override exercise category"
+        },
+        "sets": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Override number of sets"
+        },
+        "restSeconds": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "description": "Override rest between sets"
+        },
+        "rpe": {
+          "type": ["number", "null"],
+          "minimum": 1,
+          "maximum": 10,
+          "description": "Override target RPE"
+        },
+        "notes": {
+          "type": ["string", "null"],
+          "description": "Override notes"
+        },
+        "alternatives": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Override alternatives"
+        },
+        "progressionNotes": {
+          "type": ["string", "null"],
+          "description": "Override progression notes"
+        },
+        "cues": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Override cues"
+        },
+        "loadMin": {
+          "type": ["number", "null"],
+          "minimum": 0,
+          "description": "Override minimum weight"
+        },
+        "loadMax": {
+          "type": ["number", "null"],
+          "minimum": 0,
+          "description": "Override maximum weight"
+        },
+        "loadUnit": {
+          "type": ["string", "null"],
+          "enum": ["kg", "lb", "band", "bodyweight", "percent", null],
+          "description": "Override load unit"
+        },
+        "loadPerHand": {
+          "type": ["boolean", "null"],
+          "description": "Override per-hand flag"
+        },
+        "repsType": {
+          "type": ["string", "null"],
+          "enum": ["reps", "time", "ladder", "amrap", "rm", "max", "effort", "submax", "none", null],
+          "description": "Override reps type"
+        },
+        "repsValue": {
+          "oneOf": [
+            { "type": "integer", "minimum": 0 },
+            { "type": "array", "items": { "type": "integer", "minimum": 1 } },
+            { "type": "null" }
+          ],
+          "description": "Override reps value"
+        },
+        "repsMin": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "description": "Override minimum reps"
+        },
+        "repsMax": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "description": "Override maximum reps"
+        },
+        "repsUnit": {
+          "type": ["string", "null"],
+          "enum": ["seconds", "minutes", null],
+          "description": "Override reps unit"
+        },
+        "repsPerSide": {
+          "type": ["boolean", "null"],
+          "description": "Override per-side flag"
+        },
+        "repsModifier": {
+          "type": ["integer", "null"],
+          "description": "Override AMRAP modifier"
+        },
+        "tempoEccentric": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "description": "Override tempo eccentric"
+        },
+        "tempoPauseBottom": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "description": "Override tempo pause bottom"
+        },
+        "tempoConcentric": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "description": "Override tempo concentric"
+        },
+        "tempoPauseTop": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "description": "Override tempo pause top"
+        },
+        "isEmom": {
+          "type": ["boolean", "null"],
+          "description": "Override EMOM flag"
+        },
+        "isUnilateral": {
+          "type": ["boolean", "null"],
+          "description": "Override unilateral flag"
+        },
+        "supersetGroup": {
+          "type": ["integer", "null"],
+          "minimum": 1,
+          "description": "Override superset group"
+        }
+      },
+      "additionalProperties": false
+    },
+    "exercise": {
+      "type": "object",
+      "required": ["exerciseName", "sets"],
+      "properties": {
+        "exerciseName": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Full exercise name as displayed to user"
+        },
+        "exerciseId": {
+          "type": ["string", "null"],
+          "description": "Reference to exercise in library"
+        },
+        "category": {
+          "type": ["string", "null"],
+          "enum": ["warmup", "main", "accessory", "cooldown", "mobility", "skill", "core", null],
+          "description": "Exercise category"
+        },
+        "sets": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Number of sets"
+        },
+        "restSeconds": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "description": "Rest between sets in seconds"
+        },
+        "rpe": {
+          "type": ["number", "null"],
+          "minimum": 1,
+          "maximum": 10,
+          "description": "Target RPE (Rate of Perceived Exertion, 1-10)"
+        },
+        "notes": {
+          "type": ["string", "null"],
+          "description": "Training prescription and coaching cues"
+        },
+        "alternatives": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Array of alternative exercise names or IDs"
+        },
+        "progressionNotes": {
+          "type": ["string", "null"],
+          "description": "How to progress this exercise"
+        },
+        "videoUrl": {
+          "type": ["string", "null"],
+          "format": "uri",
+          "description": "Link to demonstration video"
+        },
+        "cues": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Array of coaching cue strings"
+        },
+        "loadMin": {
+          "type": ["number", "null"],
+          "minimum": 0,
+          "description": "Minimum weight value"
+        },
+        "loadMax": {
+          "type": ["number", "null"],
+          "minimum": 0,
+          "description": "Maximum weight value (same as min for fixed loads)"
+        },
+        "loadUnit": {
+          "type": ["string", "null"],
+          "enum": ["kg", "lb", "band", "bodyweight", "percent", null],
+          "description": "Load unit"
+        },
+        "loadPerHand": {
+          "type": ["boolean", "null"],
+          "description": "True if load is per hand (for dumbbell exercises)"
+        },
+        "repsType": {
+          "type": ["string", "null"],
+          "enum": ["reps", "time", "ladder", "amrap", "rm", "max", "effort", "submax", "none", null],
+          "description": "Reps type"
+        },
+        "repsValue": {
+          "oneOf": [
+            { "type": "integer", "minimum": 0 },
+            { "type": "array", "items": { "type": "integer", "minimum": 1 } },
+            { "type": "null" }
+          ],
+          "description": "Primary value (count, seconds, or ladder steps array)"
+        },
+        "repsMin": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "description": "Minimum reps for rep ranges"
+        },
+        "repsMax": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "description": "Maximum reps for rep ranges"
+        },
+        "repsUnit": {
+          "type": ["string", "null"],
+          "enum": ["seconds", "minutes", null],
+          "description": "Unit for time-based reps"
+        },
+        "repsPerSide": {
+          "type": ["boolean", "null"],
+          "description": "True if reps are per side"
+        },
+        "repsModifier": {
+          "type": ["integer", "null"],
+          "description": "Modifier for AMRAP (e.g., -1 for leave 1 rep in reserve)"
+        },
+        "tempoEccentric": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "description": "Eccentric (lowering) phase duration in seconds"
+        },
+        "tempoPauseBottom": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "description": "Pause at bottom position in seconds"
+        },
+        "tempoConcentric": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "description": "Concentric (lifting) phase duration in seconds"
+        },
+        "tempoPauseTop": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "description": "Pause at top position in seconds"
+        },
+        "isEmom": {
+          "type": ["boolean", "null"],
+          "description": "Whether this exercise uses EMOM (Every Minute On the Minute) timing"
+        },
+        "isUnilateral": {
+          "type": ["boolean", "null"],
+          "description": "Whether this exercise is performed per side"
+        },
+        "supersetGroup": {
+          "type": ["integer", "null"],
+          "minimum": 1,
+          "description": "Superset group ID. Exercises with the same supersetGroup value are performed together as a superset"
+        },
+        "reps": {
+          "type": ["string", "null"],
+          "description": "DEPRECATED: Use repsType, repsValue, repsMin, repsMax instead"
+        },
+        "load": {
+          "type": ["string", "null"],
+          "description": "DEPRECATED: Use loadMin, loadMax, loadUnit instead"
+        },
+        "tempo": {
+          "type": ["string", "null"],
+          "description": "DEPRECATED: Use tempoEccentric, tempoPauseBottom, tempoConcentric, tempoPauseTop instead"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This PR introduces workout plan format version 2.2.0 which adds support for **exercise templates**. Exercise templates allow defining common exercises once and referencing them throughout the plan, with optional field overrides.

## Key Benefits

- **45% file size reduction**: 435KB → 238KB
- **65% of exercises use templates**: 439 out of 676 exercises
- **DRY principle**: Common exercises defined once, referenced everywhere
- **Flexibility**: Override specific fields when needed

## Changes

### New Schema (`workout-plan-v2.2.schema.json`)

- Added `exerciseTemplates` array at plan level
- Each template has an `id` and all standard exercise properties
- Exercises can now be either full definitions or `{"$ref": "template-id"}`
- References can override any template field

**Example Template:**
```json
{
  "id": "warmup-rower-zone1",
  "exerciseName": "Rower (Zone 1)",
  "category": "warmup",
  "sets": 1,
  "notes": "Warm-up. Min 1-2: Easy pace to warm up (Zone 1).",
  "repsType": "time",
  "repsValue": 120,
  "repsUnit": "seconds",
  "loadMin": 0,
  "loadMax": 0,
  "loadUnit": "bodyweight",
  "restSeconds": 30
}
```

**Example Reference with Override:**
```json
{
  "$ref": "warmup-rower-zone1",
  "notes": "Custom note for this workout"
}
```

### Exercise Templates Created (21 templates)

**Warmup exercises** (appear 38-40 times each):
- `warmup-rower-zone1`, `warmup-rower-zone2`, `warmup-rower-sprints`
- `warmup-band-pull-aparts`, `warmup-band-external-rotations`
- `warmup-scapular-pullups`, `warmup-passive-bar-hang`

**Cooldown exercises** (appear 12-19 times each):
- `cooldown-passive-dead-hang`, `cooldown-butchers-block`
- `cooldown-cobra-stretch`, `cooldown-wrist-extensor`
- `cooldown-banded-pec-stretch`, `cooldown-lat-prayer`
- `cooldown-standing-quad-stretch`, `cooldown-couch-stretch`
- `cooldown-jefferson-curl`, `cooldown-90-90-hip-rotations`

**Main/Accessory exercises**:
- `main-goblet-squats`, `accessory-face-pulls`
- `core-hollow-rocks`, `core-weighted-hollow-rocks`

### Updated `workout-plan-utils.ts`

- Added `V2ExerciseTemplate` and `V2ExerciseRef` interfaces
- Updated validation to support v2.2.0 format
- Added `resolveExerciseReference()` to merge templates with overrides
- Updated `convertV2ToInternal()` to build exercise templates map
- Updated `getExercisesWithDetails()` for v2.2 support

### Migration Script (`migrate-to-v2.2.mjs`)

- Identifies common exercises by name
- Creates templates for exercises appearing 10+ times
- Replaces full definitions with `$ref` when <5 fields differ
- Preserves overrides for fields that differ from template

## Testing

- ✅ All 652 unit tests pass
- ✅ TypeScript type checking passes
- ✅ Build succeeds
- ✅ Added new tests for v2.2 exercise template resolution
- ✅ Added test for field overrides
- ✅ Added test for missing template error handling

## Backward Compatibility

- v2.0.0, v2.1.0, and v2.2.0 formats are all supported
- Existing day templates (`$ref` for days) continue to work
- The resolver handles both inline exercises and references seamlessly

## Files Changed

| File | Changes |
|------|---------|
| `workout-plan-v2.2.schema.json` | New schema with exercise templates |
| `workout-plan-v2.2.json` | Converted plan using templates |
| `src/workout-plan-utils.ts` | Added template resolution logic |
| `src/main.tsx` | Updated to load v2.2 file |
| `package.json` | Updated prebuild/predev scripts |
| `.gitignore` | Added public/workout-plan-v2.2.json |
| `migrate-to-v2.2.mjs` | Migration script |
| `src/test/workoutPlanUtils.test.jsx` | Added v2.2 tests |