### PR TITLE
feat(ui): phase 2 — brutalist workout player redesign

### DIFF
--- a/src/components/CompactSetButtons.tsx
+++ b/src/components/CompactSetButtons.tsx
@@ -73,7 +73,7 @@ const CompactSetButtonsInner: React.FC<CompactSetButtonsProps> = ({
                             <button
                                 key={`${exId}-set-${i}`}
                                 onClick={() => onToggleSet(i)}
-                                className={`h-12 w-12 min-w-[48px] rounded-xl flex items-center justify-center text-base font-bold transition-all active:scale-90 ${isDone ? 'bg-sys-onSurface text-sys-surface' : 'bg-sys-surfaceContainerHigh text-sys-onSurfaceVariant border-2 border-sys-outlineVariant'}`}
+                                className={`h-12 w-12 min-w-[48px] rounded-md flex items-center justify-center text-base font-bold tabular-nums transition-all active:scale-90 ${isDone ? 'bg-sys-onSurface text-sys-surface' : 'bg-sys-surfaceContainerHigh text-sys-onSurfaceVariant border border-sys-outlineVariant'}`}
                                 aria-label={`Set ${i + 1}${isDone ? ' completed' : ''}`}
                             >
                                 {isDone ? (
@@ -109,7 +109,7 @@ const CompactSetButtonsInner: React.FC<CompactSetButtonsProps> = ({
             </div>
             {/* Progress indicator */}
             <div
-                className={`text-sm font-bold ml-1 px-2 py-1 rounded transition-colors ${
+                className={`text-mono-stat text-sm font-bold ml-1 px-2 py-1 rounded transition-colors ${
                     isComplete
                         ? 'text-sys-success'
                         : 'text-sys-onSurfaceVar'

--- a/src/components/ExerciseCard.tsx
+++ b/src/components/ExerciseCard.tsx
@@ -545,7 +545,7 @@ const ExerciseCardImpl: React.FC<ExerciseCardProps> = ({
 
                             {completedSets > 0 && !isDensity && (
                                 <span
-                                    className={`text-xs font-bold px-2 py-0.5 rounded-full ${
+                                    className={`text-mono-stat text-xs font-bold px-2 py-0.5 rounded-full ${
                                         completedSets === totalSets
                                             ? 'bg-sys-successContainer text-sys-onSuccessContainer'
                                             : 'bg-sys-primaryContainer text-sys-onPrimaryContainer'

--- a/src/components/WorkoutTimerDisplay.tsx
+++ b/src/components/WorkoutTimerDisplay.tsx
@@ -43,7 +43,7 @@ export const WorkoutTimerDisplay: React.FC<WorkoutTimerDisplayProps> = ({
       )}
       <span
         className={clsx(
-          "font-mono text-label-lg font-bold min-w-[48px] text-left",
+          "text-mono-stat text-label-lg font-bold min-w-[48px] text-left",
           isRunning ? "text-sys-primary" : "text-sys-onSurfaceVariant"
         )}
       >

--- a/src/utils/themeUtils.ts
+++ b/src/utils/themeUtils.ts
@@ -15,17 +15,25 @@ interface ThemeColors {
 /**
  * Returns consistent color classes for different workout sections/categories.
  * Handles both ID-based types ('prep', 'main') and capitalized Display Names ('Prepare', 'Train').
+ *
+ * Brutalist (Phase 2): the `container` no longer washes the whole card with the
+ * section colour. Instead it pairs a neutral surface + hairline outline with a
+ * 3px left accent rail in the section colour. This dramatically reduces visual
+ * noise while keeping section identity scannable.
  */
 export const getSectionTheme = (typeOrCategory?: string): ThemeColors => {
     // Normalize input to lower case for comparison
     const key = typeOrCategory?.toLowerCase() || '';
 
+    // Brutalist neutral surface + hairline border, shared across sections.
+    const SURFACE = 'bg-sys-surfaceContainerLow border-sys-outlineVariant';
+
     if (key.includes('prep') || key.includes('warmup')) {
         return {
             bg: 'bg-warmup-500/15',
             border: 'border-warmup-500/50', // Higher opacity for borders in cards
-            text: 'text-warmup-100',
-            container: 'bg-warmup-500/15 border-warmup-500/50'
+            text: 'text-warmup-500',
+            container: `${SURFACE} border-l-[3px] border-l-warmup-500`,
         };
     }
 
@@ -33,8 +41,8 @@ export const getSectionTheme = (typeOrCategory?: string): ThemeColors => {
         return {
             bg: 'bg-skill-500/15',
             border: 'border-skill-500/45',
-            text: 'text-skill-100',
-            container: 'bg-skill-500/15 border-skill-500/45'
+            text: 'text-skill-500',
+            container: `${SURFACE} border-l-[3px] border-l-skill-500`,
         };
     }
 
@@ -42,8 +50,8 @@ export const getSectionTheme = (typeOrCategory?: string): ThemeColors => {
         return {
             bg: 'bg-main-500/15',
             border: 'border-main-500/40',
-            text: 'text-main-100',
-            container: 'bg-main-500/15 border-main-500/40'
+            text: 'text-main-500',
+            container: `${SURFACE} border-l-[3px] border-l-main-500`,
         };
     }
 
@@ -51,8 +59,8 @@ export const getSectionTheme = (typeOrCategory?: string): ThemeColors => {
         return {
             bg: 'bg-accessory-500/15',
             border: 'border-accessory-500/40',
-            text: 'text-accessory-100',
-            container: 'bg-accessory-500/15 border-accessory-500/40'
+            text: 'text-accessory-500',
+            container: `${SURFACE} border-l-[3px] border-l-accessory-500`,
         };
     }
 
@@ -60,8 +68,8 @@ export const getSectionTheme = (typeOrCategory?: string): ThemeColors => {
         return {
             bg: 'bg-cooldown-500/15',
             border: 'border-cooldown-500/50',
-            text: 'text-cooldown-100',
-            container: 'bg-cooldown-500/15 border-cooldown-500/50'
+            text: 'text-cooldown-500',
+            container: `${SURFACE} border-l-[3px] border-l-cooldown-500`,
         };
     }
 
@@ -70,6 +78,6 @@ export const getSectionTheme = (typeOrCategory?: string): ThemeColors => {
         bg: 'bg-sys-surface',
         border: 'border-sys-outlineVariant',
         text: 'text-sys-onSurface',
-        container: 'bg-sys-surface border-sys-outlineVariant'
+        container: SURFACE,
     };
 };


### PR DESCRIPTION
- Replace section-colour card backgrounds with neutral surface + 3px left accent rail in src/utils/themeUtils.ts. Reduces visual noise dramatically while preserving section identity at a glance.
- Square set buttons (rounded-md) and add tabular-nums to the set-completion counter in CompactSetButtons.
- Apply text-mono-stat + tabular-nums to the ExerciseCard ratio pill so set counters stay aligned across digit transitions.
- Switch WorkoutTimerDisplay to .text-mono-stat for the hero timer numeric.

No behavior changes. typecheck + build clean, 1428 unit tests pass.