### PR TITLE
feat(ui): phase 6 — brutalist modals & overlays

### DIFF
--- a/src/components/BottomSheet.tsx
+++ b/src/components/BottomSheet.tsx
@@ -169,7 +169,7 @@ export const BottomSheet: React.FC<BottomSheetProps> = ({
         >
             {/* Scrim/Backdrop */}
             <div
-                className="absolute inset-0 bg-black/60 backdrop-blur-sm animate-fade-in"
+                className="absolute inset-0 bg-black/60 animate-fade-in"
                 onClick={onClose}
                 aria-hidden="true"
             />

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -139,8 +139,8 @@ export const Dialog: React.FC<DialogProps> = ({
                     relative w-full ${maxWidth}
                     min-w-[280px]
                     modal-dialog
-                    rounded-[28px]
-                    shadow-elevation-3
+                    rounded-md
+                    border border-sys-outlineVariant
                     animate-scale-up
                     ${className}
                 `}

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -102,10 +102,8 @@ export const Snackbar: React.FC<SnackbarProps> = ({
                 className={`
                     pointer-events-auto
                     min-w-[288px] max-w-[568px] w-full sm:w-auto
-                    rounded-2xl shadow-elevation-4
-                    backdrop-blur-xl
+                    rounded-md
                     border border-sys-outlineVariant
-                    bg-opacity-90
                     animate-slide-up
                     ${typeStyles[type]}
                     ${isStacked ? 'py-3' : 'py-3.5'}
@@ -130,7 +128,7 @@ export const Snackbar: React.FC<SnackbarProps> = ({
                             <button
                                 onClick={handleAction}
                                 className={`
-                                    px-3 py-1.5 rounded-lg
+                                    px-3 py-1.5 rounded-sm
                                     text-sm font-bold
                                     transition-colors
                                     ${actionStyles[type]}
@@ -142,7 +140,7 @@ export const Snackbar: React.FC<SnackbarProps> = ({
                         <button
                             onClick={onClose}
                             className={`
-                                p-1.5 rounded-full
+                                p-1.5 rounded-sm
                                 transition-colors
                                 opacity-70 hover:opacity-100
                                 ${type === 'default' ? 'hover:bg-white/10' : 'hover:bg-black/10'}

--- a/src/components/WorkoutSummary.tsx
+++ b/src/components/WorkoutSummary.tsx
@@ -117,23 +117,23 @@ const StatCard: React.FC<StatCardProps> = ({ icon, label, value, subValue, accen
         initial={{ opacity: 0, scale: 0.9 }}
         animate={{ opacity: 1, scale: 1 }}
         transition={{ duration: 0.3 }}
-        className={`rounded-2xl p-4 border ${
+        className={`rounded-md p-4 border ${
             highlight
-                ? 'bg-sys-tertiaryContainer border-sys-tertiary/30'
+                ? 'bg-sys-surfaceContainerLow border-sys-outlineVariant'
                 : accent
-                ? 'bg-sys-primaryContainer border-sys-primary/30'
-                : 'bg-sys-surfaceContainerHigh border-sys-outlineVariant'
+                ? 'bg-sys-surfaceContainerLow border-sys-outlineVariant'
+                : 'bg-sys-surfaceContainerLow border-sys-outlineVariant'
         }`}
     >
-        <div className={`mb-2 ${highlight ? 'text-sys-onTertiaryContainer' : accent ? 'text-sys-onPrimaryContainer' : 'text-sys-onSurfaceVar'}`}>
+        <div className="mb-2 text-sys-onSurfaceVar">
             {icon}
         </div>
-        <div className={`text-2xl font-bold ${highlight ? 'text-sys-onTertiaryContainer' : accent ? 'text-sys-onPrimaryContainer' : 'text-sys-onSurface'}`}>
+        <div className="text-mono-stat text-3xl font-black text-sys-onSurface">
             {value}
         </div>
-        <div className={`text-xs ${highlight ? 'text-sys-onTertiaryContainer/70' : accent ? 'text-sys-onPrimaryContainer/70' : 'text-sys-onSurfaceVar'}`}>{label}</div>
+        <div className="eyebrow text-sys-onSurfaceVar mt-1">{label}</div>
         {subValue && (
-            <div className={`text-xs mt-1 ${highlight ? 'text-sys-onTertiaryContainer/70' : 'text-sys-onPrimaryContainer/70'}`}>
+            <div className="text-xs mt-1 text-mono-stat text-sys-onSurfaceVar">
                 {subValue}
             </div>
         )}
@@ -203,7 +203,7 @@ export const WorkoutSummary: React.FC<WorkoutSummaryProps> = ({
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
                 exit={{ opacity: 0 }}
-                className="fixed inset-0 z-50 bg-sys-surface/95 backdrop-blur-md overflow-y-auto workout-summary-container shadow-2xl"
+                className="fixed inset-0 z-50 bg-sys-surface overflow-y-auto workout-summary-container"
             >
                 <div className="min-h-full flex flex-col p-5 safe-pt safe-pb">
                     {/* Header with celebration */}
@@ -298,14 +298,14 @@ export const WorkoutSummary: React.FC<WorkoutSummaryProps> = ({
                                         initial={{ opacity: 0, x: -20 }}
                                         animate={{ opacity: 1, x: 0 }}
                                         transition={{ delay: 0.6 + idx * 0.1 }}
-                                        className="flex items-center gap-3 p-3 bg-sys-tertiaryContainer rounded-xl border border-sys-tertiary/30"
+                                        className="flex items-center gap-3 p-3 bg-sys-surfaceContainerLow rounded-md border border-sys-outlineVariant"
                                     >
-                                        <Award size={20} className="text-sys-onTertiaryContainer flex-shrink-0" />
+                                        <Award size={20} className="text-sys-onSurface flex-shrink-0" />
                                         <div className="flex-1 min-w-0">
-                                            <div className="font-semibold text-sys-onTertiaryContainer truncate">{pr.name}</div>
-                                            <div className="text-xs text-sys-onTertiaryContainer/70">{pr.weight}kg × {pr.completedSets} sets</div>
+                                            <div className="font-semibold text-sys-onSurface truncate">{pr.name}</div>
+                                            <div className="text-xs text-sys-onSurfaceVar text-mono-stat">{pr.weight}kg × {pr.completedSets} sets</div>
                                         </div>
-                                        <Zap size={16} className="text-sys-onTertiaryContainer" />
+                                        <Zap size={16} className="text-sys-onSurface" />
                                     </motion.div>
                                 ))}
                             </div>
@@ -324,16 +324,16 @@ export const WorkoutSummary: React.FC<WorkoutSummaryProps> = ({
                                 <TrendingUp size={18} className="text-sys-primary" />
                                 <h2 className="text-lg font-bold text-sys-onSurface">Highlights</h2>
                             </div>
-                            <div className="p-4 bg-sys-surfaceContainerHigh rounded-xl border border-sys-outlineVariant">
+                            <div className="p-4 bg-sys-surfaceContainerLow rounded-md border border-sys-outlineVariant">
                                 <div className="flex items-center gap-3">
-                                    <div className="h-10 w-10 rounded-xl bg-sys-primaryContainer flex items-center justify-center">
-                                        <Dumbbell size={20} className="text-sys-onPrimaryContainer" />
+                                    <div className="h-10 w-10 rounded-md bg-sys-surfaceContainerHigh border border-sys-outlineVariant flex items-center justify-center">
+                                        <Dumbbell size={20} className="text-sys-onSurface" />
                                     </div>
                                     <div className="flex-1">
-                                        <div className="text-xs text-sys-onSurfaceVar">Heaviest Lift</div>
+                                        <div className="eyebrow text-sys-onSurfaceVar">Heaviest Lift</div>
                                         <div className="font-semibold text-sys-onSurface">{stats.heaviestLift.name}</div>
                                     </div>
-                                    <div className="text-xl font-bold text-sys-primary">
+                                    <div className="text-mono-stat text-2xl font-black text-sys-onSurface">
                                         {stats.heaviestLift.weight}kg
                                     </div>
                                 </div>
@@ -349,8 +349,8 @@ export const WorkoutSummary: React.FC<WorkoutSummaryProps> = ({
                             transition={{ delay: 0.65 }}
                             className="mb-6"
                         >
-                            <div className="p-4 bg-sys-surfaceContainerHigh rounded-xl border border-sys-outlineVariant">
-                                <div className="text-xs text-sys-onSurfaceVar mb-1">Workout Notes</div>
+                            <div className="p-4 bg-sys-surfaceContainerLow rounded-md border border-sys-outlineVariant">
+                                <div className="eyebrow text-sys-onSurfaceVar mb-1">Workout Notes</div>
                                 <div className="text-sm text-sys-onSurface">{workoutNotes}</div>
                             </div>
                         </motion.div>
@@ -378,10 +378,10 @@ export const WorkoutSummary: React.FC<WorkoutSummaryProps> = ({
                                         initial={{ opacity: 0, x: -10 }}
                                         animate={{ opacity: 1, x: 0 }}
                                         transition={{ delay: 0.7 + exIdx * 0.05 }}
-                                        className={`p-4 rounded-xl border ${
+                                        className={`p-4 rounded-md border ${
                                             isExComplete
-                                                ? 'bg-sys-successContainer/10 border-sys-success/20'
-                                                : 'bg-sys-surfaceContainer border-sys-outlineVariant'
+                                                ? 'bg-sys-surfaceContainerLow border-sys-outlineVariant'
+                                                : 'bg-sys-surfaceContainerLow border-sys-outlineVariant'
                                         }`}
                                     >
                                         <div className="flex items-start justify-between gap-2 mb-2">
@@ -389,10 +389,10 @@ export const WorkoutSummary: React.FC<WorkoutSummaryProps> = ({
                                                 <h3 className="font-bold text-sys-onSurface truncate">{ex.name}</h3>
                                                 <p className="text-xs text-sys-onSurfaceVar">{ex.prescription}</p>
                                             </div>
-                                            <div className={`flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-bold ${
+                                            <div className={`flex items-center gap-1 px-2 py-0.5 rounded-sm text-xs font-bold border border-sys-outlineVariant text-mono-stat ${
                                                 isExComplete
-                                                    ? 'bg-sys-successContainer text-sys-onSuccessContainer'
-                                                    : 'bg-sys-primaryContainer text-sys-onPrimaryContainer'
+                                                    ? 'bg-sys-surfaceContainerHigh text-sys-onSurface'
+                                                    : 'bg-sys-surfaceContainerLow text-sys-onSurfaceVar'
                                             }`}>
                                                 {isExComplete && <Check size={12} />}
                                                 <span>{ex.completedSets}/{ex.totalSets}</span>
@@ -401,9 +401,9 @@ export const WorkoutSummary: React.FC<WorkoutSummaryProps> = ({
 
                                         <div className="flex items-center gap-2 flex-wrap">
                                             {ex.weight !== null && (
-                                                <div className="flex items-center gap-1.5 px-2 py-1 rounded-lg bg-sys-surfaceContainerLow border border-sys-outlineVariant">
-                                                    <Dumbbell size={12} className="text-sys-primary" />
-                                                    <span className="text-xs font-bold text-sys-onSurface">
+                                                <div className="flex items-center gap-1.5 px-2 py-1 rounded-sm bg-sys-surfaceContainerHigh border border-sys-outlineVariant">
+                                                    <Dumbbell size={12} className="text-sys-onSurface" />
+                                                    <span className="text-xs font-bold text-sys-onSurface text-mono-stat">
                                                         {ex.weight} {ex.isBodyweight ? 'BW' : 'kg'}
                                                     </span>
                                                 </div>
@@ -411,12 +411,12 @@ export const WorkoutSummary: React.FC<WorkoutSummaryProps> = ({
 
                                             {hasRPE && (
                                                 <div className="flex items-center gap-1.5">
-                                                    <span className="text-[10px] font-bold text-sys-onSurfaceVar uppercase tracking-wider ml-1">RPE:</span>
+                                                    <span className="eyebrow text-sys-onSurfaceVar ml-1">RPE:</span>
                                                     <div className="flex gap-1">
                                                         {Object.entries(ex.rpe!).map(([setIdx, rpe]) => (
                                                             <div
                                                                 key={setIdx}
-                                                                className="w-6 h-6 flex items-center justify-center rounded-md bg-sys-tertiaryContainer text-sys-onTertiaryContainer text-[10px] font-bold border border-sys-tertiary/20"
+                                                                className="w-6 h-6 flex items-center justify-center rounded-sm bg-sys-surfaceContainerHigh text-sys-onSurface text-[10px] font-bold border border-sys-outlineVariant text-mono-stat"
                                                             >
                                                                 {rpe}
                                                             </div>
@@ -439,9 +439,9 @@ export const WorkoutSummary: React.FC<WorkoutSummaryProps> = ({
                             transition={{ delay: 0.7 }}
                             className="mb-6"
                         >
-                            <div className="p-4 bg-sys-surfaceContainerHighest rounded-xl border border-sys-outlineVariant">
+                            <div className="p-4 bg-sys-surfaceContainerLow rounded-md border border-sys-outlineVariant">
                                 <div className="flex items-center justify-between mb-2">
-                                    <div className="text-xs text-sys-onSurfaceVar">Next Up</div>
+                                    <div className="eyebrow text-sys-onSurfaceVar">Next Up</div>
                                     <ChevronRight size={16} className="text-sys-onSurfaceVar" />
                                 </div>
                                 <div className="font-semibold text-sys-onSurface mb-1">Day {nextWorkout.day}</div>

--- a/src/test/md3Components.test.tsx
+++ b/src/test/md3Components.test.tsx
@@ -82,24 +82,24 @@ describe('Dialog Component', () => {
         expect(mockOnClose).toHaveBeenCalled();
     });
 
-    it('should have proper MD3 styling with 28dp radius', () => {
+    it('should have brutalist styling with rounded-md', () => {
         const { container } = render(
             <Dialog isOpen={true} onClose={mockOnClose}>
                 Dialog content
             </Dialog>
         );
         const dialog = container.querySelector('[role="dialog"]');
-        expect(dialog).toHaveClass('rounded-[28px]');
+        expect(dialog).toHaveClass('rounded-md');
     });
 
-    it('should have elevation-3 shadow', () => {
+    it('should have hairline border', () => {
         const { container } = render(
             <Dialog isOpen={true} onClose={mockOnClose}>
                 Dialog content
             </Dialog>
         );
         const dialog = container.querySelector('[role="dialog"]');
-        expect(dialog).toHaveClass('shadow-elevation-3');
+        expect(dialog).toHaveClass('border-sys-outlineVariant');
     });
 });
 
@@ -278,12 +278,12 @@ describe('Snackbar Component', () => {
         expect(snackbar).toHaveClass('bg-sys-inverseSurface');
     });
 
-    it('should have elevation-3 shadow', () => {
+    it('should have brutalist hairline border', () => {
         const { container } = render(
             <Snackbar isOpen={true} message="Test" onClose={mockOnClose} />
         );
         const snackbar = container.querySelector('[role="alert"]');
-        expect(snackbar).toHaveClass('shadow-elevation-4');
+        expect(snackbar).toHaveClass('border-sys-outlineVariant');
     });
 
     it('should apply success type styling', () => {


### PR DESCRIPTION
Brutalist redesign of modal/overlay components: hairline borders, square corners, no blur/soft-shadows.

- Snackbar: rounded-2xl + shadow-elevation-4 + backdrop-blur → rounded-md hairline; action/close rounded-sm
- Dialog: rounded-[28px] + shadow-elevation-3 → rounded-md hairline
- BottomSheet: drop scrim backdrop-blur-sm (flat bg-black/60)
- WorkoutSummary: flatten outer container (drop /95 + backdrop-blur-md + shadow-2xl); StatCards rounded-md hairline neutral with text-mono-stat values + eyebrow labels; PR row, panels, exercise rows all rounded-md hairline neutral; pills/chips rounded-sm hairline mono; eyebrow section labels
- md3Components.test: update Dialog/Snackbar assertions to brutalist classes

No behavior changes. typecheck + build clean, 1428 unit tests pass.