### PR TITLE
feat(ui): phase 7 — brutalist in-workout chrome

### DIFF
--- a/src/components/ActionBar.tsx
+++ b/src/components/ActionBar.tsx
@@ -349,7 +349,7 @@ export function ActionBar({
       {/* EMOM Timer Display */}
       {emomState && (emomState.active || emomState.seconds > 0) && setEmomActive && setEmomSeconds && setEmomInterval && (
         <div className="px-3 pt-3 pb-2 sm:px-4">
-          <div className={`bg-sys-surfaceContainerHigh px-3 py-4 sm:px-5 rounded-2xl shadow-elevation-2 relative overflow-hidden ${emomTimerJustActivated ? 'animate-slide-up' : ''}`}>
+          <div className={`bg-sys-surfaceContainerHigh px-3 py-4 sm:px-5 rounded-md border border-sys-outlineVariant relative overflow-hidden ${emomTimerJustActivated ? 'animate-slide-up' : ''}`}>
             <div
               className="absolute inset-0 bg-sys-primary/12 pointer-events-none"
               aria-hidden="true"
@@ -364,14 +364,14 @@ export function ActionBar({
               >
                 <Maximize2 size={20} />
               </button>
-              <span className="text-xs font-semibold text-sys-primary uppercase tracking-wider">
+              <span className="eyebrow text-sys-onSurface">
                 EMOM
               </span>
               {/* Round counter */}
               {emomState.round !== undefined && emomState.round > 0 && (
-                <div className="flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-sys-primaryContainer">
-                  <Repeat size={12} className="text-sys-onPrimaryContainer" />
-                  <span className="text-xs font-bold text-sys-onPrimaryContainer">
+                <div className="flex items-center gap-1.5 px-2 py-0.5 rounded-sm bg-sys-surfaceContainerHighest border border-sys-outlineVariant">
+                  <Repeat size={12} className="text-sys-onSurface" />
+                  <span className="text-xs font-bold text-sys-onSurface text-mono-stat">
                     Round {emomState.round}
                     {emomState.totalRounds && emomState.totalRounds > 0
                       ? `/${emomState.totalRounds}`
@@ -393,7 +393,7 @@ export function ActionBar({
             </div>
             <div className="flex items-center gap-2 sm:gap-4">
               <span
-                className={`text-2xl sm:text-3xl font-mono font-bold min-w-[70px] sm:min-w-[90px] transition-colors ${
+                className={`text-mono-stat text-2xl sm:text-3xl font-bold min-w-[70px] sm:min-w-[90px] transition-colors ${
                   emomState.seconds <= 5
                     ? 'text-sys-error animate-pulse'
                     : 'text-sys-onSurface'
@@ -413,7 +413,7 @@ export function ActionBar({
                 >
                   <Minus size={24} />
                 </button>
-                <span className="text-sm text-sys-onSurfaceVar font-semibold min-w-[32px] sm:min-w-[40px] text-center">
+                <span className="text-sm text-sys-onSurfaceVar font-semibold min-w-[32px] sm:min-w-[40px] text-center text-mono-stat">
                   {emomState.interval}s
                 </span>
                 <button
@@ -436,7 +436,7 @@ export function ActionBar({
       {/* Density Timer Display */}
       {densityState && (densityState.active || densityState.seconds > 0) && setDensityActive && setDensitySeconds && (
         <div className="px-3 pt-3 pb-2 sm:px-4">
-          <div className={`bg-sys-surfaceContainerHigh px-3 py-4 sm:px-5 rounded-2xl shadow-elevation-2 relative overflow-hidden ${densityTimerJustActivated ? 'animate-slide-up' : ''}`}>
+          <div className={`bg-sys-surfaceContainerHigh px-3 py-4 sm:px-5 rounded-md border border-sys-outlineVariant relative overflow-hidden ${densityTimerJustActivated ? 'animate-slide-up' : ''}`}>
             <div
               className="absolute inset-0 bg-sys-tertiary/12 pointer-events-none"
               aria-hidden="true"
@@ -451,11 +451,11 @@ export function ActionBar({
               >
                 <Maximize2 size={24} />
               </button>
-              <span className="text-xs font-semibold text-sys-tertiary uppercase tracking-wider">
+              <span className="eyebrow text-sys-onSurface">
                 Density
               </span>
-              <div className="flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-sys-tertiaryContainer">
-                <span className="text-xs font-bold text-sys-onTertiaryContainer">
+              <div className="flex items-center gap-1.5 px-2 py-0.5 rounded-sm bg-sys-surfaceContainerHighest border border-sys-outlineVariant">
+                <span className="text-xs font-bold text-sys-onSurface text-mono-stat">
                   {densityState.timeMinutes}m
                 </span>
               </div>
@@ -473,7 +473,7 @@ export function ActionBar({
             </div>
             <div className="flex items-center gap-4">
               <span
-                className={`text-2xl sm:text-3xl font-mono font-bold min-w-[70px] sm:min-w-[90px] transition-colors ${
+                className={`text-mono-stat text-2xl sm:text-3xl font-bold min-w-[70px] sm:min-w-[90px] transition-colors ${
                   densityState.seconds <= 10
                     ? 'text-sys-error animate-pulse'
                     : 'text-sys-onSurface'
@@ -514,7 +514,7 @@ export function ActionBar({
       {/* Rest Timer Display */}
       {timerState.time > 0 && (
         <div className="px-3 pt-3 pb-3 sm:px-4">
-          <div className={`bg-sys-surfaceContainerHigh px-3 py-4 sm:px-5 rounded-2xl flex items-center gap-2 sm:gap-4 shadow-elevation-2 relative overflow-hidden ${restTimerJustActivated ? 'animate-slide-up' : ''}`}>
+          <div className={`bg-sys-surfaceContainerHigh px-3 py-4 sm:px-5 rounded-md border border-sys-outlineVariant flex items-center gap-2 sm:gap-4 relative overflow-hidden ${restTimerJustActivated ? 'animate-slide-up' : ''}`}>
             <div
               className="absolute inset-0 bg-sys-secondary/12 pointer-events-none"
               aria-hidden="true"
@@ -527,7 +527,7 @@ export function ActionBar({
             >
               <Maximize2 size={24} />
             </button>
-            <span className="text-xl sm:text-2xl font-mono font-bold text-sys-onSurface min-w-[70px] sm:min-w-[80px]">
+            <span className="text-mono-stat text-xl sm:text-2xl font-bold text-sys-onSurface min-w-[70px] sm:min-w-[80px]">
               {formatSecondsShort(timerState.time)}
             </span>
             <div className="h-6 w-[1px] bg-sys-outlineVariant"></div>

--- a/src/components/AddedExerciseCard.tsx
+++ b/src/components/AddedExerciseCard.tsx
@@ -71,9 +71,9 @@ export const AddedExerciseCard: React.FC<AddedExerciseCardProps> = ({
     return (
         <div id={exId} className="relative scroll-mt-16">
             <div
-                className={`bg-sys-surface rounded-2xl p-4 border relative z-10 overflow-hidden ${
+                className={`bg-sys-surface rounded-md p-4 border relative z-10 overflow-hidden ${
                     completedSets === totalSets
-                        ? 'border-sys-successContainer bg-sys-successContainer/10'
+                        ? 'border-sys-onSurface'
                         : 'border-sys-outlineVariant'
                 }`}
             >
@@ -85,10 +85,10 @@ export const AddedExerciseCard: React.FC<AddedExerciseCardProps> = ({
                             </h3>
                             {completedSets > 0 && (
                                 <span
-                                    className={`text-xs font-bold px-2 py-0.5 rounded-full ${
+                                    className={`text-xs font-bold px-2 py-0.5 rounded-sm border text-mono-stat ${
                                         completedSets === totalSets
-                                            ? 'bg-sys-successContainer text-sys-onSuccessContainer'
-                                            : 'bg-sys-primaryContainer text-sys-onPrimaryContainer'
+                                            ? 'bg-sys-surfaceContainerHigh text-sys-onSurface border-sys-outlineVariant'
+                                            : 'bg-sys-surfaceContainerLow text-sys-onSurfaceVar border-sys-outlineVariant'
                                     }`}
                                 >
                                     {completedSets}/{totalSets}

--- a/src/components/CompactExerciseRow.tsx
+++ b/src/components/CompactExerciseRow.tsx
@@ -414,7 +414,7 @@ const CompactExerciseRowInner: React.FC<CompactExerciseRowProps> = ({
                 )}
                 <button
                     onClick={handleToggleExpand}
-                    className={`w-full h-9 px-3 flex items-center gap-2 bg-sys-successContainer/10 rounded-xl border border-sys-success/10 active:bg-sys-successContainer/30 transition-colors ${hasSupersetGroup ? 'ml-3' : ''}`}
+                    className={`w-full h-9 px-3 flex items-center gap-2 bg-sys-surfaceContainerLow rounded-md border border-sys-outlineVariant active:bg-sys-surfaceContainerHigh transition-colors ${hasSupersetGroup ? 'ml-3' : ''}`}
                     aria-label={`${historyLookupName} - completed, tap to edit`}
                 >
                     <div className="flex items-center justify-center h-5 w-5 rounded-sm bg-sys-onSurface text-sys-surface flex-shrink-0">
@@ -424,28 +424,28 @@ const CompactExerciseRowInner: React.FC<CompactExerciseRowProps> = ({
                         {shortDisplayName}
                     </span>
                     {isEmom && (
-                        <span className="inline-flex items-center gap-0.5 text-[9px] font-bold px-1 py-0.5 rounded-full bg-sys-tertiaryContainer text-sys-onTertiaryContainer flex-shrink-0">
+                        <span className="inline-flex items-center gap-0.5 text-[9px] font-bold px-1 py-0.5 rounded-sm bg-sys-surfaceContainerHigh text-sys-onSurface border border-sys-outlineVariant flex-shrink-0">
                             <Zap size={8} strokeWidth={3} />
                         </span>
                     )}
                     {isDensity && (
-                        <span className="inline-flex items-center gap-0.5 text-[9px] font-bold px-1 py-0.5 rounded-full bg-sys-primaryContainer text-sys-onPrimaryContainer flex-shrink-0">
+                        <span className="inline-flex items-center gap-0.5 text-[9px] font-bold px-1 py-0.5 rounded-sm bg-sys-surfaceContainerHigh text-sys-onSurface border border-sys-outlineVariant flex-shrink-0">
                             <Gauge size={8} strokeWidth={3} />
                         </span>
                     )}
                     {isAmrap && (
-                        <span className="inline-flex items-center gap-0.5 text-[9px] font-bold px-1 py-0.5 rounded-full bg-sys-errorContainer text-sys-onErrorContainer flex-shrink-0">
+                        <span className="inline-flex items-center gap-0.5 text-[9px] font-bold px-1 py-0.5 rounded-sm bg-sys-surfaceContainerHigh text-sys-onSurface border border-sys-outlineVariant flex-shrink-0">
                             <TrendingUp size={8} strokeWidth={3} />
                         </span>
                     )}
                     {isLadder && (
-                        <span className="inline-flex items-center gap-0.5 text-[9px] font-bold px-1 py-0.5 rounded-full bg-sys-successContainer text-sys-onSuccessContainer flex-shrink-0">
+                        <span className="inline-flex items-center gap-0.5 text-[9px] font-bold px-1 py-0.5 rounded-sm bg-sys-surfaceContainerHigh text-sys-onSurface border border-sys-outlineVariant flex-shrink-0">
                             <BarChart2 size={8} strokeWidth={3} />
                             {ladderReps && <span className="text-[8px]">{ladderReps.join('-')}</span>}
                         </span>
                     )}
                     {isUnilateral && (
-                        <span className="inline-flex items-center gap-0.5 text-[9px] font-bold px-1 py-0.5 rounded-full bg-sys-secondaryContainer text-sys-onSecondaryContainer flex-shrink-0">
+                        <span className="inline-flex items-center gap-0.5 text-[9px] font-bold px-1 py-0.5 rounded-sm bg-sys-surfaceContainerHigh text-sys-onSurface border border-sys-outlineVariant flex-shrink-0">
                             <span className="text-[8px]">L/R</span>
                         </span>
                     )}
@@ -478,7 +478,7 @@ const CompactExerciseRowInner: React.FC<CompactExerciseRowProps> = ({
                         />
                     )}
                     {!isDensity && (
-                        <span className="text-xs text-sys-onSurfaceVariant font-semibold">
+                        <span className="text-xs text-sys-onSurfaceVariant font-semibold text-mono-stat">
                             {completedSets}/{totalSets}
                         </span>
                     )}
@@ -511,7 +511,7 @@ const CompactExerciseRowInner: React.FC<CompactExerciseRowProps> = ({
                 </>
             )}
             <div
-                className={`rounded-xl border overflow-hidden transition-all ${containerClasses} ${hasSupersetGroup ? 'ml-3' : ''}`}
+                className={`rounded-md border overflow-hidden transition-all ${containerClasses} ${hasSupersetGroup ? 'ml-3' : ''}`}
             >
             {/* Main Row - Always visible */}
             <div className="h-16 px-3 flex items-center gap-2">

--- a/src/components/ContinueWorkoutCard.tsx
+++ b/src/components/ContinueWorkoutCard.tsx
@@ -48,7 +48,7 @@ export function ContinueWorkoutCard({ workout, onResume }: ContinueWorkoutCardPr
       </div>
 
       {totalSets > 0 && (
-        <div className="w-full bg-sys-surfaceContainerHigh h-2 rounded-full overflow-hidden mb-4">
+        <div className="w-full bg-sys-surfaceContainerHigh h-2 rounded-sm overflow-hidden mb-4">
           <div
             className="h-full bg-sys-primary transition-all duration-500 ease-out"
             style={{ width: `${progressPercent}%` }}
@@ -58,7 +58,7 @@ export function ContinueWorkoutCard({ workout, onResume }: ContinueWorkoutCardPr
 
       <div className="grid grid-cols-2 gap-4 pt-4 border-t border-sys-outlineVariant">
         <div>
-          <div className="text-label-sm text-sys-onSurfaceVariant mb-1">
+          <div className="eyebrow text-sys-onSurfaceVariant mb-1">
             Last activity
           </div>
           <div className="text-body-md font-semibold text-sys-onSurface">
@@ -66,18 +66,18 @@ export function ContinueWorkoutCard({ workout, onResume }: ContinueWorkoutCardPr
           </div>
         </div>
         <div>
-          <div className="text-label-sm text-sys-onSurfaceVariant mb-1">
+          <div className="eyebrow text-sys-onSurfaceVariant mb-1">
             Workout
           </div>
-          <div className="text-body-md font-semibold text-sys-onSurface">
+          <div className="text-body-md font-semibold text-sys-onSurface text-mono-stat">
             Week {week} • Day {day}
           </div>
         </div>
         <div className="col-span-2">
-          <div className="text-label-sm text-sys-onSurfaceVariant mb-1">
+          <div className="eyebrow text-sys-onSurfaceVariant mb-1">
             Progress
           </div>
-          <div className="text-body-md font-semibold text-sys-onSurface">
+          <div className="text-body-md font-semibold text-sys-onSurface text-mono-stat">
             {progress}
           </div>
         </div>

--- a/src/components/DensityRepControls.tsx
+++ b/src/components/DensityRepControls.tsx
@@ -104,7 +104,7 @@ export const DensityRepControls = ({
                             <button
                                 key={val}
                                 onClick={() => handleQuickAdd(val)}
-                                className="h-10 px-3 min-w-[40px] rounded-xl bg-sys-tertiaryContainer text-sys-onTertiaryContainer text-sm font-bold active:scale-95 transition-all shadow-elevation-1 hover:shadow-elevation-2 flex items-center justify-center border border-sys-tertiary/20"
+                                className="h-10 px-3 min-w-[40px] rounded-sm bg-sys-surfaceContainerHigh text-sys-onSurface text-sm font-bold active:scale-95 transition-all flex items-center justify-center border border-sys-outlineVariant text-mono-stat"
                                 aria-label={`Add ${val} reps`}
                             >
                                 +{val}
@@ -125,7 +125,7 @@ export const DensityRepControls = ({
                         </div>
                         <button
                             onClick={handleUndo}
-                            className="flex items-center gap-1.5 px-2 py-1 rounded-lg bg-sys-surfaceContainerHighest text-sys-onSurface text-[10px] font-bold active:scale-95 transition-all shadow-elevation-1 border border-sys-outlineVariant/20"
+                            className="flex items-center gap-1.5 px-2 py-1 rounded-sm bg-sys-surfaceContainerHigh text-sys-onSurface text-[10px] font-bold active:scale-95 transition-all border border-sys-outlineVariant"
                             aria-label="Undo last entry"
                         >
                             <Minus size={12} />

--- a/src/test/addedExerciseCard.test.tsx
+++ b/src/test/addedExerciseCard.test.tsx
@@ -146,7 +146,7 @@ describe('AddedExerciseCard', () => {
                 />
             );
 
-            const card = container.querySelector('.border-sys-successContainer');
+            const card = container.querySelector('.border-sys-onSurface');
             expect(card).toBeInTheDocument();
         });
 


### PR DESCRIPTION
Brutalist redesign of in-workout chrome components.

- ContinueWorkoutCard: progress bar rounded-sm; eyebrow labels for Last activity/Workout/Progress; mono week·day and progress numerics
- AddedExerciseCard: rounded-md hairline (drop rounded-2xl, success tint); ratio pill rounded-sm hairline mono
- ActionBar EMOM/Density/Rest timer panels: rounded-md hairline (drop rounded-2xl + shadow-elevation-2); eyebrow EMOM/Density labels; round/minute counters rounded-sm hairline mono; timer numerics text-mono-stat (drop font-mono)
- DensityRepControls: quick-add buttons rounded-sm hairline mono (drop rounded-xl + shadow-elevation-1/2 + tertiary tint); Undo button rounded-sm hairline
- CompactExerciseRow: collapsed completed row rounded-md hairline neutral surface; active container rounded-md; all type badges rounded-sm hairline neutral; ratio numerics text-mono-stat
- addedExerciseCard test: assert new completion border (border-sys-onSurface)

No behavior changes. typecheck + build clean, 1428 unit tests pass.