### PR TITLE
feat(ui): phase 8 — brutalist library, programs, skeletons & onboarding

### DIFF
--- a/src/components/ExerciseListItem.tsx
+++ b/src/components/ExerciseListItem.tsx
@@ -54,30 +54,30 @@ export const ExerciseListItem: React.FC<ExerciseListItemProps> = ({
     };
 
     return (
-        <div className={`rounded-2xl p-4 ${
+        <div className={`rounded-md p-4 border ${
             exercise.category === 'mobility'
-                ? 'bg-sys-primaryContainer/40 border border-sys-primary/30'
-                : 'bg-sys-surfaceContainerLow'
+                ? 'bg-sys-surfaceContainerLow border-sys-outline'
+                : 'bg-sys-surfaceContainerLow border-sys-outlineVariant'
         }`}>
             <div className="flex items-start justify-between gap-3">
                 <div className="flex-1">
                     <h4 className="text-base font-semibold text-sys-onSurface mb-1">
                         {exercise.name}
                     </h4>
-                    <p className="text-xs text-sys-onSurfaceVariant mb-2">
+                    <p className="eyebrow text-sys-onSurfaceVariant mb-2">
                         {exercise.primaryMuscles.join(', ')}
                     </p>
                     <div className="flex flex-wrap gap-1">
                         {exercise.equipment.slice(0, 3).map((eq) => (
                             <span
                                 key={eq}
-                                className="text-xs px-2 py-1 bg-sys-surfaceContainer rounded-lg text-sys-onSurfaceVariant"
+                                className="text-xs px-2 py-1 bg-sys-surfaceContainerHigh border border-sys-outlineVariant rounded-sm text-sys-onSurfaceVariant"
                             >
                                 {eq}
                             </span>
                         ))}
                         {!exercise.isBodyweight && (
-                            <span className="text-xs px-2 py-1 bg-sys-primaryContainer rounded-lg text-sys-onPrimaryContainer">
+                            <span className="text-xs px-2 py-1 bg-sys-surfaceContainerHigh border border-sys-outlineVariant rounded-sm text-sys-onSurface">
                                 Weighted
                             </span>
                         )}
@@ -90,7 +90,7 @@ export const ExerciseListItem: React.FC<ExerciseListItemProps> = ({
                             haptic.tick();
                             setShowAddForm(true);
                         }}
-                        className="btn-filled h-10 px-4 rounded-xl font-semibold text-sm active:scale-95 transition-transform flex-shrink-0 shadow-elevation-1 hover:shadow-elevation-2"
+                        className="btn-filled h-10 px-4 rounded-sm font-semibold text-sm active:scale-95 transition-transform flex-shrink-0"
                     >
                         Add
                     </button>
@@ -100,7 +100,7 @@ export const ExerciseListItem: React.FC<ExerciseListItemProps> = ({
                             haptic.tick();
                             setShowAddForm(false);
                         }}
-                        className="h-10 w-10 rounded-xl bg-sys-surfaceContainerHighest text-sys-onSurface flex items-center justify-center active:scale-95 transition-transform flex-shrink-0"
+                        className="h-10 w-10 rounded-sm bg-sys-surfaceContainerHigh border border-sys-outlineVariant text-sys-onSurface flex items-center justify-center active:scale-95 transition-transform flex-shrink-0"
                         aria-label="Collapse form"
                     >
                         <ChevronUp size={20} />

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -126,7 +126,7 @@ export const Onboarding: React.FC<OnboardingProps> = ({ onComplete }) => {
             <div className="flex-1 flex flex-col items-center justify-center px-8 text-center">
                 {/* Icon with animated entrance - decorative, hidden from screen readers */}
                 <div
-                    className="h-28 w-28 rounded-full bg-sys-surfaceHigh flex items-center justify-center mb-8 animate-fade-in"
+                    className="h-28 w-28 rounded-md bg-sys-surfaceContainerLow border border-sys-outlineVariant flex items-center justify-center mb-8 animate-fade-in"
                     key={currentStep}
                     aria-hidden="true"
                 >
@@ -153,9 +153,9 @@ export const Onboarding: React.FC<OnboardingProps> = ({ onComplete }) => {
                     <button
                         key={index}
                         onClick={() => handleDotClick(index)}
-                        className={`h-2 rounded-full transition-all duration-300 ${
+                        className={`h-2 rounded-sm transition-all duration-300 ${
                             index === currentStep
-                                ? 'w-8 bg-sys-primary'
+                                ? 'w-8 bg-sys-onSurface'
                                 : 'w-2 bg-sys-surfaceContainerHigh hover:bg-sys-onSurfaceVariant'
                         }`}
                         aria-current={index === currentStep ? 'step' : undefined}

--- a/src/components/ProgramSelector.tsx
+++ b/src/components/ProgramSelector.tsx
@@ -114,10 +114,10 @@ function ProgramCard({ program, isActive, onSelect, isLoading }: ProgramCardProp
       role="option"
       aria-selected={isActive}
       aria-label={`${program.name}${isActive ? ' (Active)' : ''}, ${program.durationWeeks} weeks, ${getTargetLevelLabel(program.targetLevel)}`}
-      className={`w-full p-4 rounded-2xl border text-left transition-all ${
+      className={`w-full p-4 rounded-md border text-left transition-all ${
         isActive
-          ? 'bg-sys-primaryContainer border-sys-primary'
-          : 'bg-sys-surfaceContainerLow border-sys-outlineVariant hover:border-sys-outline active:scale-[0.98]'
+          ? 'bg-sys-surfaceContainerHigh border-sys-onSurface'
+          : 'bg-sys-surfaceContainerLow border-sys-outlineVariant hover:border-sys-outline active:scale-[0.99]'
       } ${isLoading ? 'opacity-50 cursor-wait' : ''}`}
     >
       <div className="flex items-start justify-between gap-3">
@@ -125,7 +125,7 @@ function ProgramCard({ program, isActive, onSelect, isLoading }: ProgramCardProp
           <div className="flex items-center gap-2 mb-1">
             <h4 className="text-base font-semibold text-sys-onSurface truncate">{program.name}</h4>
             {isActive && (
-              <span className="flex items-center gap-1 px-2 py-0.5 rounded-full bg-sys-primary text-sys-onPrimary text-xs font-medium" aria-hidden="true">
+              <span className="flex items-center gap-1 px-2 py-0.5 rounded-sm bg-sys-onSurface text-sys-surface text-xs font-bold border border-sys-onSurface" aria-hidden="true">
                 <Check size={12} />
                 Active
               </span>
@@ -140,13 +140,13 @@ function ProgramCard({ program, isActive, onSelect, isLoading }: ProgramCardProp
 
           <div className="flex flex-wrap items-center gap-2">
             {/* Duration */}
-            <span className="flex items-center gap-1 text-xs text-sys-onSurfaceVar">
+            <span className="flex items-center gap-1 text-xs text-sys-onSurfaceVar text-mono-stat">
               <Clock size={12} aria-hidden="true" />
               {program.durationWeeks} weeks
             </span>
 
             {/* Target Level */}
-            <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${getTargetLevelColor(program.targetLevel)}`}>
+            <span className={`px-2 py-0.5 rounded-sm text-xs font-medium border border-sys-outlineVariant ${getTargetLevelColor(program.targetLevel)}`}>
               {getTargetLevelLabel(program.targetLevel)}
             </span>
 
@@ -163,12 +163,12 @@ function ProgramCard({ program, isActive, onSelect, isLoading }: ProgramCardProp
 
         {/* Selection indicator */}
         <div
-          className={`flex-shrink-0 w-6 h-6 rounded-full border-2 flex items-center justify-center transition-colors ${
-            isActive ? 'bg-sys-primary border-sys-primary' : 'border-sys-outline'
+          className={`flex-shrink-0 w-6 h-6 rounded-sm border-2 flex items-center justify-center transition-colors ${
+            isActive ? 'bg-sys-onSurface border-sys-onSurface' : 'border-sys-outline'
           }`}
           aria-hidden="true"
         >
-          {isActive && <Check size={14} className="text-sys-onPrimary" />}
+          {isActive && <Check size={14} className="text-sys-surface" />}
         </div>
       </div>
     </button>

--- a/src/components/skeletons/Skeletons.tsx
+++ b/src/components/skeletons/Skeletons.tsx
@@ -4,9 +4,9 @@ import React from 'react';
  * ExerciseCardSkeleton - Loading placeholder for exercise cards
  */
 export const ExerciseCardSkeleton: React.FC = () => (
-    <div className="bg-sys-surface rounded-2xl p-5 border border-white/5 animate-pulse">
+    <div className="bg-sys-surface rounded-md p-5 border border-sys-outlineVariant animate-pulse">
         <div className="flex items-center gap-4 mb-4">
-            <div className="h-12 w-12 rounded-xl bg-sys-surfaceHigh" />
+            <div className="h-12 w-12 rounded-md bg-sys-surfaceHigh" />
             <div className="flex-1">
                 <div className="h-5 bg-sys-surfaceHigh rounded w-3/4 mb-2" />
                 <div className="h-3 bg-sys-surfaceHigh rounded w-1/2" />
@@ -14,7 +14,7 @@ export const ExerciseCardSkeleton: React.FC = () => (
         </div>
         <div className="flex gap-2">
             {[1, 2, 3].map(i => (
-                <div key={i} className="h-14 flex-1 rounded-xl bg-sys-surfaceHigh" />
+                <div key={i} className="h-14 flex-1 rounded-md bg-sys-surfaceHigh" />
             ))}
         </div>
     </div>
@@ -24,13 +24,13 @@ export const ExerciseCardSkeleton: React.FC = () => (
  * HistoryEntrySkeleton - Loading placeholder for history timeline entries
  */
 export const HistoryEntrySkeleton: React.FC = () => (
-    <div className="bg-sys-surface rounded-2xl p-5 border border-white/5 animate-pulse">
+    <div className="bg-sys-surface rounded-md p-5 border border-sys-outlineVariant animate-pulse">
         <div className="flex items-start justify-between mb-4">
             <div className="flex-1">
                 <div className="h-5 bg-sys-surfaceHigh rounded w-1/3 mb-2" />
                 <div className="h-4 bg-sys-surfaceHigh rounded w-1/4" />
             </div>
-            <div className="h-10 w-10 rounded-full bg-sys-surfaceHigh" />
+            <div className="h-10 w-10 rounded-md bg-sys-surfaceHigh" />
         </div>
         <div className="space-y-2">
             <div className="h-4 bg-sys-surfaceHigh rounded w-full" />
@@ -43,7 +43,7 @@ export const HistoryEntrySkeleton: React.FC = () => (
  * StatsCardSkeleton - Loading placeholder for stats cards
  */
 export const StatsCardSkeleton: React.FC = () => (
-    <div className="bg-sys-surface rounded-2xl p-4 border border-white/5 animate-pulse">
+    <div className="bg-sys-surface rounded-md p-4 border border-sys-outlineVariant animate-pulse">
         <div className="flex items-center justify-between mb-3">
             <div className="flex items-center gap-2">
                 <div className="h-8 w-8 rounded-lg bg-sys-surfaceHigh" />
@@ -62,14 +62,14 @@ export const StatsCardSkeleton: React.FC = () => (
  * ExerciseLibraryItemSkeleton - Loading placeholder for exercise library items
  */
 export const ExerciseLibraryItemSkeleton: React.FC = () => (
-    <div className="bg-sys-surface rounded-2xl p-4 border border-white/5 animate-pulse">
+    <div className="bg-sys-surface rounded-md p-4 border border-sys-outlineVariant animate-pulse">
         <div className="flex items-center gap-3">
-            <div className="h-12 w-12 rounded-xl bg-sys-surfaceHigh flex-shrink-0" />
+            <div className="h-12 w-12 rounded-md bg-sys-surfaceHigh flex-shrink-0" />
             <div className="flex-1 min-w-0">
                 <div className="h-5 bg-sys-surfaceHigh rounded w-2/3 mb-2" />
                 <div className="h-3 bg-sys-surfaceHigh rounded w-1/2" />
             </div>
-            <div className="h-10 w-10 rounded-full bg-sys-surfaceHigh flex-shrink-0" />
+            <div className="h-10 w-10 rounded-md bg-sys-surfaceHigh flex-shrink-0" />
         </div>
     </div>
 );

--- a/src/test/skeletons.test.tsx
+++ b/src/test/skeletons.test.tsx
@@ -50,7 +50,7 @@ describe('Skeleton Components', () => {
 
         it('has rounded corners styling', () => {
             const { container } = render(<StatsCardSkeleton />);
-            expect(container.firstChild).toHaveClass('rounded-2xl');
+            expect(container.firstChild).toHaveClass('rounded-md');
         });
     });
 
@@ -75,7 +75,7 @@ describe('Skeleton Components', () => {
         it('includes multiple exercise card skeletons', () => {
             const { container } = render(<WorkoutDaySkeleton />);
             // Should have 3 exercise cards
-            const cards = container.querySelectorAll('.rounded-2xl');
+            const cards = container.querySelectorAll('.rounded-md');
             expect(cards.length).toBeGreaterThanOrEqual(3);
         });
     });


### PR DESCRIPTION
Brutalist redesign of library, programs, skeletons and onboarding.

- Skeletons: rounded-2xl/rounded-xl/rounded-full → rounded-md throughout; outlineVariant hairlines (drop white/5)
- skeletons.test: assert rounded-md instead of rounded-2xl
- ExerciseListItem: rounded-md hairline (drop rounded-2xl + primaryContainer/40 mobility tint); equipment chips rounded-sm hairline neutral; eyebrow muscle list; Add button rounded-sm flat (drop shadow-elevation-1/2); collapse button rounded-sm hairline
- ProgramSelector: cards rounded-md; active = bg-sys-surfaceContainerHigh border-sys-onSurface (drop primaryContainer tint); Active badge rounded-sm onSurface; selection indicator rounded-sm square (drop rounded-full circle); level pill rounded-sm hairline; duration text-mono-stat
- Onboarding: icon backdrop rounded-md hairline (drop rounded-full); progress dots rounded-sm with onSurface active (drop primary)

No behavior changes. typecheck + build clean, 1428 unit tests pass.