### PR TITLE
feat(ui): phase 9 — brutalist ExerciseCard outer, FullscreenTimer & shared chip/segmented CSS

### DIFF
--- a/src/components/ExerciseCard.tsx
+++ b/src/components/ExerciseCard.tsx
@@ -410,7 +410,7 @@ const ExerciseCardImpl: React.FC<ExerciseCardProps> = ({
 
         // First incomplete gets accent ring + subtle primary glow on top of section color (only when not in focus view)
         if (isFirstIncomplete && !hideCollapseButton) {
-            return `${sectionColors} ring-2 ring-sys-primary/50 shadow-elevation-2`;
+            return `${sectionColors} ring-1 ring-sys-onSurface`;
         }
 
         return sectionColors;
@@ -428,7 +428,7 @@ const ExerciseCardImpl: React.FC<ExerciseCardProps> = ({
             )}
 
             <div
-                className={`rounded-2xl p-4 border relative z-10 overflow-hidden ${containerClasses}`}
+                className={`rounded-md p-4 border relative z-10 overflow-hidden ${containerClasses}`}
             >
                 {/* Progress bar */}
                 {completedSets > 0 && (
@@ -460,7 +460,7 @@ const ExerciseCardImpl: React.FC<ExerciseCardProps> = ({
                                         haptic.tick();
                                         onShowAlternatives(name, alternatives);
                                     }}
-                                    className="h-6 w-6 rounded-full bg-sys-surfaceHigh text-sys-onSurfaceVar flex items-center justify-center active:scale-90 transition-all"
+                                    className="h-6 w-6 rounded-sm bg-sys-surfaceContainerHigh border border-sys-outlineVariant text-sys-onSurfaceVar flex items-center justify-center active:scale-90 transition-all"
                                     aria-label="Swap to alternative exercise"
                                 >
                                     <ArrowRightLeft size={12} />

--- a/src/components/FullscreenTimer.tsx
+++ b/src/components/FullscreenTimer.tsx
@@ -356,8 +356,8 @@ export const FullscreenTimer: React.FC<FullscreenTimerProps> = ({
 
           {/* Pause indicator */}
           {isPaused && !isComplete && (
-            <div className="mt-2 px-4 py-2 rounded-full bg-sys-surfaceContainerHigh backdrop-blur-md border border-sys-outlineVariant">
-              <span className="text-sys-onSurface text-sm font-bold uppercase tracking-wider">Paused</span>
+            <div className="mt-2 px-4 py-2 rounded-sm bg-sys-surfaceContainerHigh border border-sys-outlineVariant">
+              <span className="eyebrow text-sys-onSurface">Paused</span>
             </div>
           )}
         </div>
@@ -387,11 +387,11 @@ export const FullscreenTimer: React.FC<FullscreenTimerProps> = ({
                 <button
                   onClick={() => handleAdjustInterval(-5)}
                   disabled={totalSeconds <= 10}
-                  className="h-16 w-16 md:h-18 md:w-18 rounded-3xl bg-sys-surfaceContainerHigh hover:bg-sys-surfaceContainerHighest disabled:opacity-30 text-sys-onSurface flex flex-col items-center justify-center gap-1 active:scale-90 transition-all font-medium"
+                  className="h-16 w-16 md:h-18 md:w-18 rounded-md bg-sys-surfaceContainerHigh border border-sys-outlineVariant hover:bg-sys-surfaceContainerHighest disabled:opacity-30 text-sys-onSurface flex flex-col items-center justify-center gap-1 active:scale-90 transition-all font-medium"
                   aria-label="Decrease interval by 5 seconds"
                 >
                   <Minus size={20} />
-                  <span className="text-[10px] uppercase font-bold tracking-wider">5s</span>
+                  <span className="eyebrow">5s</span>
                 </button>
 
                 <button
@@ -413,7 +413,7 @@ export const FullscreenTimer: React.FC<FullscreenTimerProps> = ({
                   aria-label="Reduce density timer by 30 seconds"
                 >
                   <Minus size={20} />
-                  <span className="text-[10px] uppercase font-bold tracking-wider">30s</span>
+                  <span className="eyebrow">30s</span>
                 </button>
 
                 <button
@@ -442,7 +442,7 @@ export const FullscreenTimer: React.FC<FullscreenTimerProps> = ({
                   aria-label="Subtract 30 seconds"
                 >
                   <Minus size={20} />
-                  <span className="text-[10px] uppercase font-bold tracking-wider">30s</span>
+                  <span className="eyebrow">30s</span>
                 </button>
 
                 <button

--- a/src/main.css
+++ b/src/main.css
@@ -1569,7 +1569,7 @@ input[type="number"]::-webkit-outer-spin-button { -webkit-appearance: none; marg
     display: flex;
     width: 100%;
     background: var(--color-surface-variant);
-    border-radius: var(--radius-xl);
+    border-radius: var(--radius-sm);
     padding: 4px;
     border: 1px solid var(--color-outline-variant);
 }
@@ -1581,7 +1581,7 @@ input[type="number"]::-webkit-outer-spin-button { -webkit-appearance: none; marg
     justify-content: center;
     gap: 8px;
     min-height: 40px;
-    border-radius: var(--radius-lg);
+    border-radius: var(--radius-sm);
     font-size: 14px;
     font-weight: 500;
     color: var(--color-on-surface-variant);
@@ -1592,9 +1592,10 @@ input[type="number"]::-webkit-outer-spin-button { -webkit-appearance: none; marg
 }
 
 .segmented-button.active {
-    background: var(--color-primary-container);
-    color: var(--color-on-primary-container);
-    box-shadow: var(--elevation-1);
+    background: var(--color-surface-container-highest);
+    color: var(--color-on-surface);
+    box-shadow: none;
+    border: 1px solid var(--color-outline-variant);
 }
 
 .segmented-button:hover:not(.active) {
@@ -1626,12 +1627,12 @@ input[type="number"]::-webkit-outer-spin-button { -webkit-appearance: none; marg
     height: 32px;
     min-height: 32px;
     padding: 0 16px;
-    border-radius: 8px;
+    border-radius: var(--radius-sm);
     font-size: 14px;
     font-weight: 500;
     letter-spacing: 0.1px;
     line-height: 20px;
-    border: 1px solid var(--color-outline);
+    border: 1px solid var(--color-outline-variant);
     background: transparent;
     color: var(--color-on-surface-variant);
     cursor: pointer;
@@ -1648,9 +1649,9 @@ input[type="number"]::-webkit-outer-spin-button { -webkit-appearance: none; marg
 /* Selected state - MD3 filter chip */
 .chip.active,
 .chip[aria-selected="true"] {
-    background: var(--color-secondary-container);
-    color: var(--color-on-secondary-container);
-    border-color: transparent;
+    background: var(--color-surface-container-highest);
+    color: var(--color-on-surface);
+    border-color: var(--color-on-surface);
 }
 
 /* Hover state - unselected */

--- a/src/test/exerciseCard.test.tsx
+++ b/src/test/exerciseCard.test.tsx
@@ -414,8 +414,8 @@ describe('ExerciseCard', () => {
                 <ExerciseCard {...defaultProps} isFirstIncomplete={true} />
             );
 
-            // Should have primary ring when first incomplete
-            const card = container.querySelector('.ring-sys-primary\\/50');
+            // Should have onSurface ring when first incomplete
+            const card = container.querySelector('.ring-sys-onSurface');
             expect(card).toBeInTheDocument();
         });
 


### PR DESCRIPTION
Final brutalist pass: ExerciseCard outer container, FullscreenTimer remnants, and shared .chip/.segmented-button CSS classes.

- ExerciseCard: outer rounded-2xl → rounded-md; first-incomplete highlight ring-2 ring-sys-primary/50 + shadow-elevation-2 → ring-1 ring-sys-onSurface; swap-alternative button rounded-full bg-sys-surfaceHigh → rounded-sm hairline neutral
- FullscreenTimer: Paused indicator rounded-full + backdrop-blur-md → rounded-sm hairline (drop blur); Paused label → eyebrow; EMOM -5 button rounded-3xl → rounded-md hairline; all 5s/30s suffix labels → eyebrow (drop tracking-wider)
- main.css .segmented-button-container: rounded-xl → rounded-sm; .segmented-button: rounded-lg → rounded-sm; .segmented-button.active: primary-container + elevation-1 → surface-container-highest hairline (no shadow)
- main.css .chip: 8px radius → rounded-sm var; outline → outline-variant; .chip.active: secondary-container tinted → surface-container-highest with on-surface hairline (no tint)
- exerciseCard test: assert ring-sys-onSurface

No behavior changes. typecheck + build clean, 1428 unit tests pass.